### PR TITLE
feature: add createdelegatetxraw() to support create raw delegate transaction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,7 +654,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, CBaseTransact
     	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s has been confirmed\n", hash.GetHex()), REJECT_INVALID, "tx-duplicate-confirmed");
 
     if (pBaseTx->IsCoinBase())
-    	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s is coin base tx,can't put into mempool", hash.GetHex()), REJECT_INVALID, "tx-coinbase-to-mempool");
+    	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s is coin base tx, can't put into mempool", hash.GetHex()), REJECT_INVALID, "tx-coinbase-to-mempool");
 	// is it in valid height
 	if (!pBaseTx->IsValidHeight(chainActive.Tip()->nHeight, SysCfg().GetTxCacheHeight())) {
 		return state.Invalid(ERRORMSG("AcceptToMemoryPool() : txhash=%s beyond the scope of valid height\n ", hash.GetHex()),

--- a/src/rpc/rpcclient.cpp
+++ b/src/rpc/rpcclient.cpp
@@ -198,6 +198,10 @@ Array RPCConvertValues(const string &strMethod, const vector<string> &strParams)
     if(strMethod == "createdelegatetx"       && n > 2) ConvertTo<int64_t>(params[2]);
     if(strMethod == "createdelegatetx"       && n > 3) ConvertTo<int>(params[3]);
 
+    if(strMethod == "createdelegatetxraw"       && n > 1) ConvertTo<Array>(params[1]);
+    if(strMethod == "createdelegatetxraw"       && n > 2) ConvertTo<int64_t>(params[2]);
+    if(strMethod == "createdelegatetxraw"       && n > 3) ConvertTo<int>(params[3]);
+
     if (strMethod == "registerapptx"          && n > 2) ConvertTo<int64_t>(params[2]);
     if (strMethod == "registerapptx"          && n > 3) ConvertTo<int>(params[3]);
 

--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -290,6 +290,7 @@ static const CRPCCommand vRPCCommands[] =
     { "registaccounttx",        &registaccounttx,      	 true,      false,      true },
 	{ "createcontracttx",       &createcontracttx,       true,      false,      true },
 	{ "createdelegatetx",       &createdelegatetx,       true,      false,      true },
+    { "createdelegatetxraw",    &createdelegatetxraw,    true,      false,      true },
 	{ "registerapptx",       	&registerapptx,          true,      false,      true },
 	{ "settxfee",               &settxfee,               false,     false,      true },
 	{ "walletlock",             &walletlock,             true,      false,      true },

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -847,8 +847,8 @@ Value createdelegatetxraw(const Array& params, bool fHelp) {
     //get keyid
     CKeyID keyid;
     if (!GetKeyId(sendAddr, keyid)) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw :address err");
-    }
+		throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw Error: Send tx address error.");
+	}
     CDelegateTransaction delegateTx;
     assert(pwalletMain != NULL);
     {
@@ -859,8 +859,8 @@ Value createdelegatetxraw(const Array& params, bool fHelp) {
 
         CUserID userId = keyid;
         if (!view.GetAccount(userId, account)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account balance is insufficient.");
-        }
+			throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account is not exist.");
+		}
 
         if (!account.IsRegister()) {
             throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account is not registered.");
@@ -889,16 +889,16 @@ Value createdelegatetxraw(const Array& params, bool fHelp) {
             const Value& delegateAddress = find_value(operVote.get_obj(), "delegate");
             const Value& delegateVotes = find_value(operVote.get_obj(),  "votes");
             if(delegateAddress.type() == null_type || delegateVotes == null_type) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "in createdelegatetxraw :vote fund address error or fund value error.");
-            }
+				throw JSONRPCError(RPC_INVALID_PARAMETER, "in createdelegatetxraw Error: Voted delegator's address type error or vote value error.");
+			}
             CKeyID delegateKeyId;
             if (!GetKeyId(delegateAddress.get_str(), delegateKeyId)) {
-                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw :address error.");
-            }
+				throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw Error: Voted delegator's address error.");
+			}
             CAccount delegateAcct;
             if (!view.GetAccount(CUserID(delegateKeyId), delegateAcct)) {
-                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw Error: delegate address is not registered.");
-            }
+				throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw Error: Voted delegator's address is not registered.");
+			}
             operVoteFund.fund.pubKey = delegateAcct.PublicKey;
             operVoteFund.fund.value = (uint64_t)abs(delegateVotes.get_int64());
             if(delegateVotes.get_int64() > 0 ) {
@@ -908,10 +908,6 @@ Value createdelegatetxraw(const Array& params, bool fHelp) {
                 operVoteFund.operType = MINUS_FUND;
             }
             delegateTx.operVoteFunds.push_back(operVoteFund);
-        }
-
-        if (!pwalletMain->Sign(keyid, delegateTx.SignatureHash(), delegateTx.signature)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Sign failed.");
         }
     }
 
@@ -2649,7 +2645,7 @@ Value listasset(const Array& params, bool fHelp) {
 	}
 
 	CRegID script(params[0].get_str());
-	
+
 	Array retArry;
 	assert(pwalletMain != NULL);
 	{
@@ -3164,12 +3160,12 @@ Value getdelegatelist(const Array& params, bool fHelp) {
           char *stopstring;
           llVotes = strtoul(strVoltes.c_str(), &stopstring, 16);
 		  */
-		  
+
 		  stringstream strValue;
 		  strValue.flags(ios::hex);
 		  strValue << strVoltes;
 		  strValue >> llVotes;
-	
+
           vector<unsigned char> vAcctRegId(iterVotes+26, vScriptKey.end());
           CRegID acctRegId(vAcctRegId);
           CAccount account;

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -812,6 +812,116 @@ Value createdelegatetx(const Array& params, bool fHelp) {
     return obj;
 }
 
+//create a delegate raw transaction
+Value createdelegatetxraw(const Array& params, bool fHelp) {
+    if (fHelp || params.size() <  3  || params.size() > 4) {
+            throw runtime_error("createdelegatetxraw \"addr\" \"opervotes\" \"fee\" \"height\"\n"
+                    "\ncreate a delegate transaction\n"
+                    "\nArguments:\n"
+                    "1.\"addr\": (string required) send delegate transaction address\n"
+                    "2. \"opervotes\"    (string, required) A json array of json oper vote to delegates\n"
+                    " [\n"
+                      " {\n"
+                      "    \"delegate\":\"address\", (string, required) The transaction id\n"
+                      "    \"votes\":n  (numeric, required) votes\n"
+                      " }\n"
+                      "       ,...\n"
+                    " ]\n"
+                    "3.\"fee\": (numeric required) pay to miner\n"
+                    "4.\"height\": (numeric optional)valid height,If not provide, use the tip block hegiht in chainActive\n"
+                    "\nResult:\n"
+                    "\"txhash\": (string)\n"
+                    "\nExamples:\n"
+                    + HelpExampleCli("createdelegatetxraw"," \"wQquTWgzNzLtjUV4Du57p9YAEGdKvgXs9t\" \"[{\\\"delegate\\\":\\\"wNDue1jHcgRSioSDL4o1AzXz3D72gCMkP6\\\", \\\"votes\\\":100000000}]\" 1000") + "\nAs json rpc call\n"
+                    + HelpExampleRpc("createdelegatetxraw"," \"wQquTWgzNzLtjUV4Du57p9YAEGdKvgXs9t\" \"[{\\\"delegate\\\":\\\"wNDue1jHcgRSioSDL4o1AzXz3D72gCMkP6\\\", \\\"votes\\\":100000000}]\" 1000"));
+    }
+    RPCTypeCheck(params, list_of(str_type)(array_type)(int_type)(int_type));
+    string sendAddr = params[0].get_str();
+    uint64_t fee = params[2].get_uint64();
+    int nHeight = 0;
+    if(params.size() > 3) {
+        nHeight = params[3].get_int();
+    }
+    Array operVoteArray = params[1].get_array();
+
+    //get keyid
+    CKeyID keyid;
+    if (!GetKeyId(sendAddr, keyid)) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw :address err");
+    }
+    CDelegateTransaction delegateTx;
+    assert(pwalletMain != NULL);
+    {
+        EnsureWalletIsUnlocked();
+        //balance
+        CAccountViewCache view(*pAccountViewTip, true);
+        CAccount account;
+
+        CUserID userId = keyid;
+        if (!view.GetAccount(userId, account)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account balance is insufficient.");
+        }
+
+        if (!account.IsRegister()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account is not registered.");
+        }
+
+        uint64_t balance = account.GetRawBalance();
+        if (balance < fee) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Account balance is insufficient.");
+        }
+
+        if (!pwalletMain->HaveKey(keyid)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Send tx address is not in wallet file.");
+        }
+
+        delegateTx.llFees = fee;
+        if( 0 != nHeight) {
+            delegateTx.nValidHeight = nHeight;
+        }
+        else {
+            delegateTx.nValidHeight = chainActive.Tip()->nHeight;
+        }
+        delegateTx.userId = account.regID;
+
+        for(auto operVote : operVoteArray) {
+            COperVoteFund operVoteFund;
+            const Value& delegateAddress = find_value(operVote.get_obj(), "delegate");
+            const Value& delegateVotes = find_value(operVote.get_obj(),  "votes");
+            if(delegateAddress.type() == null_type || delegateVotes == null_type) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "in createdelegatetxraw :vote fund address error or fund value error.");
+            }
+            CKeyID delegateKeyId;
+            if (!GetKeyId(delegateAddress.get_str(), delegateKeyId)) {
+                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw :address error.");
+            }
+            CAccount delegateAcct;
+            if (!view.GetAccount(CUserID(delegateKeyId), delegateAcct)) {
+                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "in createdelegatetxraw Error: delegate address is not registered.");
+            }
+            operVoteFund.fund.pubKey = delegateAcct.PublicKey;
+            operVoteFund.fund.value = (uint64_t)abs(delegateVotes.get_int64());
+            if(delegateVotes.get_int64() > 0 ) {
+                operVoteFund.operType = ADD_FUND;
+            }
+            else {
+                operVoteFund.operType = MINUS_FUND;
+            }
+            delegateTx.operVoteFunds.push_back(operVoteFund);
+        }
+
+        if (!pwalletMain->Sign(keyid, delegateTx.SignatureHash(), delegateTx.signature)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "in createdelegatetxraw Error: Sign failed.");
+        }
+    }
+
+	CDataStream ds(SER_DISK, CLIENT_VERSION);
+	std::shared_ptr<CBaseTransaction> pBaseTx = delegateTx.GetNewInstance();
+	ds << pBaseTx;
+	Object obj;
+	obj.push_back(Pair("rawtx", HexStr(ds.begin(), ds.end())));
+	return obj;
+}
 
 Value listaddr(const Array& params, bool fHelp) {
 	if (fHelp || params.size() != 0) {

--- a/src/rpc/rpctx.h
+++ b/src/rpc/rpctx.h
@@ -26,6 +26,7 @@ extern Value signcontracttx(const Array& params, bool fHelp);
 extern Value createfreezetx(const Array& params, bool fHelp);
 extern Value registerapptx(const Array& params, bool fHelp);
 extern Value createdelegatetx(const Array& params, bool fHelp);
+extern Value createdelegatetxraw(const Array& params, bool fHelp);
 
 extern Value listaddr(const Array& params, bool fHelp);
 extern Value listtx(const Array& params, bool fHelp);


### PR DESCRIPTION
As it's known to all, one can construct  an offline transaction by the following steps:
1. create a raw transaction
2. sign the raw transaction with private key
3. submit the signed transaction to the blockchain network

If provided the createdelegatetxraw(), one can create a raw delegate transaction safely first, then sign the raw transaction with private key, finally, submit the signed transaction to the blockchain network.