### PR TITLE
fix: sigstr support sign raw transaction with type DELEGATE_TX

### DIFF
--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -3124,7 +3124,7 @@ Value getrawtx(const Array& params, bool fHelp) {
         streamRawTx << pDelegateTx->signature;
     }
 	else {
-		 throw runtime_error("seiralize tx type value error, must be ranger(1...5)\n");
+		 throw runtime_error("seiralize tx type value error, must be ranger(1...6)\n");
 	}
 	vector<unsigned char> vRetCh(streamRawTx.begin(), streamRawTx.end());
 	Object obj;

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -2504,6 +2504,17 @@ Value sigstr(const Array& params, bool fHelp) {
 		obj.push_back(Pair("rawtx", HexStr(ds.begin(), ds.end())));
 	}
 		break;
+	case DELEGATE_TX: {
+		std::shared_ptr<CDelegateTransaction> tx = std::make_shared<CDelegateTransaction>(pBaseTx.get());
+		if (!pwalletMain->Sign(keyid, tx.get()->SignatureHash(), tx.get()->signature)) {
+			throw JSONRPCError(RPC_INVALID_PARAMETER, "Sign failed");
+		}
+		CDataStream ds(SER_DISK, CLIENT_VERSION);
+		std::shared_ptr<CBaseTransaction> pBaseTx = tx->GetNewInstance();
+		ds << pBaseTx;
+		obj.push_back(Pair("rawtx", HexStr(ds.begin(), ds.end())));
+	}
+		break;
 	default:
 //		assert(0);
 		break;

--- a/src/tx.h
+++ b/src/tx.h
@@ -1051,7 +1051,7 @@ void Serialize(Stream& os, const std::shared_ptr<CBaseTransaction> &pa, int nTyp
 	    Serialize(os, *((CDelegateTransaction *) (pa.get())), nType, nVersion);
 	}
 	else {
-		throw ios_base::failure("seiralize tx type value error, must be ranger(1...5)");
+		throw ios_base::failure("seiralize tx type value error, must be ranger(1...6)");
 	}
 
 }
@@ -1085,7 +1085,7 @@ void Unserialize(Stream& is, std::shared_ptr<CBaseTransaction> &pa, int nType, i
         Unserialize(is, *((CDelegateTransaction *) (pa.get())), nType, nVersion);
 	}
 	else {
-		throw ios_base::failure("unseiralize tx type value error, must be ranger(1...5)");
+		throw ios_base::failure("unseiralize tx type value error, must be ranger(1...6)");
 	}
 	pa->nTxType = nTxType;
 }


### PR DESCRIPTION
When we call `sigstr` to sign a raw delegate transaction, the return is null.

Let's focus on `sigstr`, we can find that theinterface do `NOT` support raw transaction with type `DELEGATE_TX`.

In order to fix it, we need to add the following code snippet:
```cpp
case DELEGATE_TX: {
    std::shared_ptr<CDelegateTransaction> tx = std::make_shared<CDelegateTransaction>(pBaseTx.get());
    if (!pwalletMain->Sign(keyid, tx.get()->SignatureHash(), tx.get()->signature)) {
        throw JSONRPCError(RPC_INVALID_PARAMETER, "Sign failed");
    }
    CDataStream ds(SER_DISK, CLIENT_VERSION);
    std::shared_ptr<CBaseTransaction> pBaseTx = tx->GetNewInstance();
    ds << pBaseTx;
    obj.push_back(Pair("rawtx", HexStr(ds.begin(), ds.end())));
}
    break;
```