### PR TITLE
fix: throw specific exception when tx already in mempool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -648,7 +648,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, CBaseTransact
     // is it already in the memory pool?
     uint256 hash = pBaseTx->GetHash();
     if (pool.exists(hash))
-        return false;
+    	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s already in mempool\n", hash.GetHex()), REJECT_INVALID, "tx-already-in-mempool");
     // is it already confirmed in block
     if(uint256() != pTxCacheTip->IsContainTx(hash))
     	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s has been confirmed\n", hash.GetHex()), REJECT_INVALID, "tx-duplicate-confirmed");
@@ -657,7 +657,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, CBaseTransact
     	return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s is coin base tx, can't put into mempool", hash.GetHex()), REJECT_INVALID, "tx-coinbase-to-mempool");
 	// is it in valid height
 	if (!pBaseTx->IsValidHeight(chainActive.Tip()->nHeight, SysCfg().GetTxCacheHeight())) {
-		return state.Invalid(ERRORMSG("AcceptToMemoryPool() : txhash=%s beyond the scope of valid height\n ", hash.GetHex()),
+		return state.Invalid(ERRORMSG("AcceptToMemoryPool() : tx hash %s beyond the scope of valid height\n ", hash.GetHex()),
 				REJECT_INVALID, "tx-invalid-height");
 	}
 


### PR DESCRIPTION
When we submit two transactions continuously with the same parameters, i.e., the first transaction is not confirmed but only in mempool, the wallet throws an exception with error code -8 without any specific reasons like this.

```code
root@ubuntu:~/WaykiChain/node# ./coind -datadir=. sendtoaddress wTyQ8Qr1GirxdbF5EJcuuCNUFbAN5vJKsc 100000
{
    "hash" : "e76151d172538a3321d9a1ef2a41b50d9e9e184a13b3f87da1d449bed3273c96"
}
root@ubuntu:~/WaykiChain/node# ./coind -datadir=. sendtoaddress wTyQ8Qr1GirxdbF5EJcuuCNUFbAN5vJKsc 100000
error: {"code":-8,"message":""}
```

We can throw an exception with a specific reason to indicate the cause of the error like this.

```code
root@ubuntu:~/WaykiChain/node# ./coind -datadir=. sendtoaddress wTyQ8Qr1GirxdbF5EJcuuCNUFbAN5vJKsc 100000
{
    "hash" : "dd96dbfdd5a45a50fb1e40049c9256af14a90a4e2c58126533da98def07ed676"
}
root@ubuntu:~/WaykiChain/node# ./coind -datadir=. sendtoaddress wTyQ8Qr1GirxdbF5EJcuuCNUFbAN5vJKsc 100000
error: {"code":-8,"message":"tx-already-in-mempool"}
```