### PR TITLE
fix: block spacing jitter

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -65,14 +65,14 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
 /** Do mining precalculation */
 void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash1);
 
-bool CreatePosTx(const uint64_t currentTime, const CAccount &delegate, CAccountViewCache &view, CBlock *pBlock);
+bool CreatePosTx(const int64_t currentTime, const CAccount &delegate, CAccountViewCache &view, CBlock *pBlock);
 
 bool GetDelegatesAcctList(vector<CAccount> & vDelegatesAcctList);
 bool GetDelegatesAcctList(vector<CAccount> & vDelegatesAcctList, CAccountViewCache &accViewIn, CTransactionDBCache &txCacheIn, CScriptDBViewCache &scriptCacheIn);
 
 void ShuffleDelegates(const int nCurHeight, vector<CAccount> &vDelegatesList);
 
-bool GetCurrentDelegate(const vector<CAccount> & vDelegatesAcctList, const int64_t currentTime, CAccount &delegateAcct);
+bool GetCurrentDelegate(const int64_t currentTime,  const vector<CAccount> &vDelegatesAcctList, CAccount &delegateAcct);
 
 bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache, bool bNeedRunTx = false);
 /** Check mined block */


### PR DESCRIPTION
**存在的问题**
随机扰动算法选择新一轮的记账账户时，有概率发生碰撞（即，选择的新一轮记账账户与上一轮记账账户相同），该机制本身不存在问题。只要前后两个区块的出块间隔满足出块间隔，即使由同一个记账账户连续出块也合理。

在当前实现中，由于如下判断条件不当，将导致出块间隔抖动

```code
if(pBlock->GetBlockTime()-preBlock.GetBlockTime() < SysCfg().GetTargetSpacing()) {
    if(preDelegate.regID == delegate.regID) {
        return ERRORMSG("one delegate can't produce more than one block at the same slot");
    }
}
```

**错误原因**
错误地取 pBlock->GetBlockTime() 当做当前时间，如果当前时间与上一个区块出块时间间隔满足大于出块间隔，将导致错误地进入分支，然后，每隔一秒钟取获取当前出块节点，直到 snot 变更，虽然也能找到一个记账账户出块，但是导致出块间隔抖动

**修复方式**
每次取当前时间与上一区块出块时间进行比较

**复现步骤**

> 记账账户个数越少，碰撞概率越大。因此，建议在 regtest 设置 3 个记账账户进行复现

1. 启动节点并持续运行出块
2. 统计各个区块出块间隔

