### PR TITLE
performance: improve getblockcount rpc performance

### DIFF
--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -244,7 +244,7 @@ static const CRPCCommand vRPCCommands[] =
     /* Block chain and UTXO */
     { "getblockchaininfo",      &getblockchaininfo,      true,      false,      false },
     { "getbestblockhash",       &getbestblockhash,       true,      false,      false },
-    { "getblockcount",          &getblockcount,          true,      false,      false },
+    { "getblockcount",          &getblockcount,          true,      true,       false },
     { "getblock",               &getblock,               false,     false,      false },
     { "getblockhash",           &getblockhash,           false,     false,      false },
     { "getdifficulty",          &getdifficulty,          true,      false,      false },


### PR DESCRIPTION
**What's the problem**

`getblockcount` is frequently used to query the blockchain's height. In fact, it's can be accomplished only via read operation.

But in current implementation, `getblockcount` is `NOT` set to be thread safe in `rpcthread.h` like this

```code
static const CRPCCommand vRPCCommands[] =
{ //  name                      actor (function)         okSafeMode threadSafe reqWallet
  //  ------------------------  -----------------------  ---------- ---------- ---------
    /* Block chain and UTXO */
    { "getblock",               &getblock,               false,     false,      false },
    ...
}
```

On condition of `not-thread-safe`, the rpc server thread will handle the rpc call of `getblockcount` like this

```code
// Execute
Value result;
{
    if (pcmd->threadSafe)
	result = pcmd->actor(params, false);
    else if (!pwalletMain) {
	LOCK(cs_main);
	result = pcmd->actor(params, false);
    } else {
	LOCK2(cs_main, pwalletMain->cs_wallet);
	result = pcmd->actor(params, false);
    }
}
```

Although read operation only is used in `getblockcount`, the rpc server thread will try to acquire lock. If the lock is frequently raced by all threads, the rpc call will be blocked for a long time. 
For example, it's easy to replicate the problem when starting a new node to sync the blockchain.

**How to fix**
Set `getblockcount` to thread safe to fix the problem.
