### PR TITLE
fix: call sigstr failed for unnecessary check

### DIFF
--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -2533,10 +2533,6 @@ Value sigstr(const Array& params, bool fHelp) {
 	switch (pBaseTx.get()->nTxType) {
 	case COMMON_TX: {
 		std::shared_ptr<CTransaction> tx = std::make_shared<CTransaction>(pBaseTx.get());
-		CKeyID keyid;
-		if (!view.GetKeyId(tx.get()->srcRegId, keyid)) {
-			throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "vaccountid have no key id");
-		}
 		if (!pwalletMain->Sign(keyid, tx.get()->SignatureHash(), tx.get()->signature)) {
 			throw JSONRPCError(RPC_INVALID_PARAMETER, "Sign failed");
 		}


### PR DESCRIPTION
**存在的问题**
`sigstr` 功能：使用账户私钥对未签名的交易进行签名。因此，只需要该节点（钱包中）存在账户的私钥，就应当可以对未签名的交易进行签名。如果某个节点存在账户的私钥，且没有同步该账户的账户信息，那么，如下的检测将会失败，进而导致 RPC 调用失败。

```code
CKeyID keyID;
if (!view.GetKeyId(tx.get()->srcRegId, keyID)) {
    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "vaccountid have no key id");
}
```
实际上，此处检测是不必要的。

**复现步骤**
假设离线节点 X，在线节点 Y
1. 在 X 上生成账户 a
2. 将账户 a 导入节点 Y
3. 在 Y 激活账户 a
4. 在 Y 上生成任意一笔未签名的普通交易
5. 在 X 上利用 `sigstr` 尝试对 4 中交易签名，此时将失败

**修复方式**
去掉多余的检测即可。