### PR TITLE
feature: provide decoderawtransaction rpc

### DIFF
--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -321,11 +321,12 @@ static const CRPCCommand vRPCCommands[] =
     { "islocked",               &islocked,               true,      false,      true },
     { "getsignature",           &getsignature,           true,      false,      true },
     { "getdelegatelist",        &getdelegatelist,        true,      false,      true },
+    { "decoderawtransaction",   &decoderawtransaction,   false,     false,      false},
 
 //for test code
-	{ "gettxoperationlog",      &gettxoperationlog,      false,     false,      false },
+	{ "gettxoperationlog",      &gettxoperationlog,      false,     false,      false},
     { "disconnectblock",        &disconnectblock,        true,      false,      true },
-    { "resetclient",            &resetclient,            true,      false,      false },
+    { "resetclient",            &resetclient,            true,      false,      false},
     { "reloadtxcache",          &reloadtxcache,          true,      false,      true },
     { "listsetblockindexvalid", &listsetblockindexvalid, true,      false,      false},
     { "getappregid",  			&getappregid,            true,      false,      false},
@@ -525,7 +526,7 @@ static void RPCAcceptHandler(std::shared_ptr< basic_socket_acceptor<Protocol, So
 void StartRPCThreads()
 {
     strRPCUserColonPass = SysCfg().GetArg("-rpcuser", "") + ":" + SysCfg().GetArg("-rpcpassword", "");
-    
+
     string rpcuser = SysCfg().GetArg("-rpcuser", "");
     string rpcpassword = SysCfg().GetArg("-rpcpassword", "");
     // RPC user/password required but empty or equal to each other

--- a/src/rpc/rpcserver.h
+++ b/src/rpc/rpcserver.h
@@ -169,6 +169,7 @@ extern json_spirit::Value createcontracttxraw(const json_spirit::Array& params, 
 extern json_spirit::Value createfreezetxraw(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value registerscripttxraw(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sigstr(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value decoderawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value printblokdbinfo(const json_spirit::Array& params, bool fHelp);
 
 

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -462,7 +462,7 @@ Value createcontracttx(const Array& params, bool fHelp) {
 					"411994-1"
 					"01020304 "
 					"1") + "\nAs json rpc call\n"
-			+ HelpExampleRpc("createcontracttx", 
+			+ HelpExampleRpc("createcontracttx",
 					"wQWKaN4n7cr1HLqXY3eX65rdQMAL5R34k6 [\"411994-1\"] "
 					"\"5yNhSL7746VV5qWHHDNLkSQ1RYeiheryk9uzQG6C5d\""
 					"100000 "
@@ -472,7 +472,7 @@ Value createcontracttx(const Array& params, bool fHelp) {
 
 	RPCTypeCheck(params, list_of(str_type)(str_type)(int_type)(str_type)(int_type)(int_type));
 
-	//argument-1: sender's base58 addr  
+	//argument-1: sender's base58 addr
 	CRegID userId(params[0].get_str());
 	CKeyID srckeyid;
 	if (userId.IsEmpty()) {
@@ -2586,6 +2586,61 @@ Value sigstr(const Array& params, bool fHelp) {
 		std::shared_ptr<CBaseTransaction> pBaseTx = tx->GetNewInstance();
 		ds << pBaseTx;
 		obj.push_back(Pair("rawtx", HexStr(ds.begin(), ds.end())));
+	}
+		break;
+	default:
+//		assert(0);
+		break;
+	}
+	return obj;
+}
+
+Value decoderawtransaction(const Array& params, bool fHelp) {
+	if (fHelp || params.size() != 1) {
+		throw runtime_error("decoderawtransaction \"hexstring\"\n"
+				"\ndecode transaction\n"
+				"\nArguments:\n"
+				"1.\"str\": (string, required) hexstring\n"
+				"\nExamples:\n"
+				+ HelpExampleCli("decoderawtransaction", "\"03015f020001025a0164cd10004630440220664de5ec373f44d2756a23d5267ab25f22af6162d166b1cca6c76631701cbeb5022041959ff75f7c7dd39c1f9f6ef9a237a6ea467d02d2d2c3db62a1addaa8009ccd\"")
+				+ "\nAs json rpc call\n"
+				+ HelpExampleRpc("decoderawtransaction", "\"03015f020001025a0164cd10004630440220664de5ec373f44d2756a23d5267ab25f22af6162d166b1cca6c76631701cbeb5022041959ff75f7c7dd39c1f9f6ef9a237a6ea467d02d2d2c3db62a1addaa8009ccd\""));
+	}
+	vector<unsigned char> vch(ParseHex(params[0].get_str()));
+	Object obj;
+	CDataStream stream(vch, SER_DISK, CLIENT_VERSION);
+	std::shared_ptr<CBaseTransaction> pBaseTx;
+	stream >> pBaseTx;
+	if (!pBaseTx.get()) {
+		return obj;
+	}
+	CAccountViewCache view(*pAccountViewTip, true);
+	switch (pBaseTx.get()->nTxType) {
+	case COMMON_TX: {
+		std::shared_ptr<CTransaction> tx = std::make_shared<CTransaction>(pBaseTx.get());
+		obj = tx->ToJSON(view);
+	}
+		break;
+	case REG_ACCT_TX: {
+		std::shared_ptr<CRegisterAccountTx> tx = std::make_shared<CRegisterAccountTx>(pBaseTx.get());
+		obj = tx->ToJSON(view);
+	}
+		break;
+	case CONTRACT_TX: {
+		std::shared_ptr<CTransaction> tx = std::make_shared<CTransaction>(pBaseTx.get());
+		obj = tx->ToJSON(view);
+	}
+		break;
+	case REWARD_TX:
+		break;
+	case REG_APP_TX: {
+		std::shared_ptr<CRegisterAppTx> tx = std::make_shared<CRegisterAppTx>(pBaseTx.get());
+		obj = tx->ToJSON(view);
+	}
+		break;
+	case DELEGATE_TX: {
+		std::shared_ptr<CDelegateTransaction> tx = std::make_shared<CDelegateTransaction>(pBaseTx.get());
+		obj = tx->ToJSON(view);
 	}
 		break;
 	default:


### PR DESCRIPTION
**Purpose**
Providing `decoderawtransaction` rpc, the developers can check the raw transaction as needed, especially when they construct a transaction and sign it on their own.

In a word, `decoderawtransaction` will be helpful to developers to accomplish their work.

**Example**

```code
root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. getaccountinfo wcSECPcKdCxLkuwobZqEeEJsDk9Shp8JDe
{
    "Address" : "wcSECPcKdCxLkuwobZqEeEJsDk9Shp8JDe",
    "KeyID" : "b85bc5a4f704b9a45e3c84cc5a9e7599ba0a9665",
    "RegID" : " ",
    "PublicKey" : "03d9e7ec535d27ea9efd195be1d7a7449b6fd69b1ef4688f98c0dbf74902cf246d",
    "MinerPKey" : "",
    "Balance" : 10000,
    "Votes" : 0,
    "UpdateHeight" : 0,
    "voteFundList" : [
    ],
    "postion" : "inblock"
}

root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. registeraccounttxraw 100 13 03d9e7ec535d27ea9efd195be1d7a7449b6fd69b1ef4688f98c0dbf74902cf246d
{
    "rawtx" : "02010d2103d9e7ec535d27ea9efd195be1d7a7449b6fd69b1ef4688f98c0dbf74902cf246d006446304402206b3120d2737322580a7535cea0d888bb3715474b5577c58229d96d0578816b6a02200a0de610d785b8077b894794f7a8b1a8435773227dab45d658df1be3a1ac28cf"
}

root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. decodetransaction 02010d2103d9e7ec535d27ea9efd195be1d7a7449b6fd69b1ef4688f98c0dbf74902cf246d006446304402206b3120d2737322580a7535cea0d888bb3715474b5577c58229d96d0578816b6a02200a0de610d785b8077b894794f7a8b1a8435773227dab45d658df1be3a1ac28cf
{
    "hash" : "7cbe2320b98c07fb8007a5533f8b95bafa2a191cb016509bedf216e64516d474",
    "txtype" : "REG_ACCT_TX",
    "ver" : 1,
    "addr" : "wcSECPcKdCxLkuwobZqEeEJsDk9Shp8JDe",
    "pubkey" : "03d9e7ec535d27ea9efd195be1d7a7449b6fd69b1ef4688f98c0dbf74902cf246d",
    "miner_pubkey" : "",
    "fees" : 100,
    "height" : 13
}
```

```code
root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. sendtoaddressraw 100 10000 0-1 wcSECPcKdCxLkuwobZqEeEJsDk9Shp8JDe 95
{
    "rawtx" : "03015f020001025a0164cd10004630440220664de5ec373f44d2756a23d5267ab25f22af6162d166b1cca6c76631701cbeb5022041959ff75f7c7dd39c1f9f6ef9a237a6ea467d02d2d2c3db62a1addaa8009ccd"
}

root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. decodetransaction 03015f020001025a0164cd10004630440220664de5ec373f44d2756a23d5267ab25f22af6162d166b1cca6c76631701cbeb5022041959ff75f7c7dd39c1f9f6ef9a237a6ea467d02d2d2c3db62a1addaa8009ccd
{
    "hash" : "d9454477c28f07376e1911ad58bc82102bf7780549ff8f2d833c2bbb0c88083a",
    "txtype" : "COMMON_TX",
    "ver" : 1,
    "regid" : "0-1",
    "addr" : "wLKf2NqwtHk3BfzK5wMDfbKYN1SC3weyR4",
    "desregid" : "90-1",
    "desaddr" : "wcSECPcKdCxLkuwobZqEeEJsDk9Shp8JDe",
    "money" : 10000,
    "fees" : 100,
    "height" : 95,
    "Contract" : ""
}
```