### PR TITLE
remodule CTransaction::ToString()

### DIFF
--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -636,8 +636,8 @@ string CTransaction::ToString(CAccountViewCache &view) const {
 	} else if (desUserId.type() == typeid(CRegID)) {
 		desId = boost::get<CRegID>(desUserId).ToString();
 	}
-	str += strprintf("txType=%s, hash=%s, ver=%d, srcId=%s desId=%s, llFees=%ld, vContract=%s, nValidHeight=%d\n",
-	txTypeArray[nTxType], GetHash().ToString().c_str(), nVersion, boost::get<CRegID>(srcRegId).ToString(), desId.c_str(), llFees, HexStr(vContract).c_str(), nValidHeight);
+	str += strprintf("txType=%s, hash=%s, ver=%d, srcId=%s desId=%s, llValues=%ld, llFees=%ld, vContract=%s, nValidHeight=%d\n",
+	txTypeArray[nTxType], GetHash().ToString().c_str(), nVersion, boost::get<CRegID>(srcRegId).ToString(), desId.c_str(), llValues, llFees, HexStr(vContract).c_str(), nValidHeight);
 	return str;
 }
 


### PR DESCRIPTION
The `amount` is a basic property in a common transaction, it's helpful
to print the `amount`.

**before**
```code
2019-01-07 08:27:22 [wallet/wallet.cpp:415]INFO: CommitTransaction:
txType=COMMON_TX, hash=46ef83ebe93b9be4a3d962e0eb7ac8390c0da2d54f0836885cb09ae8b688c264, ver=1, srcId=0-1 desId=0-2, llFees=10000, vContract=, nValidHeight=0
```

**after**
```code
2019-01-07 08:27:22 [wallet/wallet.cpp:415]INFO: CommitTransaction:
txType=COMMON_TX, hash=46ef83ebe93b9be4a3d962e0eb7ac8390c0da2d54f0836885cb09ae8b688c264, ver=1, srcId=0-1 desId=0-2, llValues=10999, llFees=10000, vContract=, nValidHeight=0
```