### PR TITLE
performance: improve tps

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -328,19 +328,19 @@ class CTransactionDBView {
     virtual bool IsContainBlock(const CBlock &block);
     virtual bool AddBlockToCache(const CBlock &block);
     virtual bool DeleteBlockFromCache(const CBlock &block);
-    virtual bool LoadTransaction(map<uint256, vector<uint256> > &mapTxHashByBlockHash);
-    virtual bool BatchWrite(const map<uint256, vector<uint256> > &mapTxHashByBlockHashIn);
+    virtual bool LoadTransaction(map<uint256, set<uint256> > &mapTxHashByBlockHash);
+    virtual bool BatchWrite(const map<uint256, set<uint256> > &mapTxHashByBlockHashIn);
     virtual ~CTransactionDBView(){};
 };
 
 class CTransactionDBViewBacked : public CTransactionDBView {
    protected:
     CTransactionDBView *pBase;
-    bool LoadTransaction(map<uint256, vector<uint256> > &mapTxHashByBlockHash);
+    bool LoadTransaction(map<uint256, set<uint256> > &mapTxHashByBlockHash);
 
    public:
     CTransactionDBViewBacked(CTransactionDBView &transactionView);
-    bool BatchWrite(const map<uint256, vector<uint256> > &mapTxHashByBlockHashIn);
+    bool BatchWrite(const map<uint256, set<uint256> > &mapTxHashByBlockHashIn);
     uint256 HasTx(const uint256 &txHash);
     bool IsContainBlock(const CBlock &block);
     bool AddBlockToCache(const CBlock &block);
@@ -350,8 +350,8 @@ class CTransactionDBViewBacked : public CTransactionDBView {
 class CTransactionDBCache : public CTransactionDBViewBacked {
    private:
     CTransactionDBCache(CTransactionDBCache &transactionView);
-    map<uint256, vector<uint256> > mapTxHashByBlockHash;  // key:block hash  value:tx hash
-    bool IsInMap(const map<uint256, vector<uint256> > &mMap, const uint256 &hash) const;
+    map<uint256, set<uint256> > mapTxHashByBlockHash;  // key:block hash  value:tx hash
+    bool IsInMap(const map<uint256, set<uint256> > &mMap, const uint256 &hash) const;
 
    public:
     CTransactionDBCache(CTransactionDBView &pTxCacheDB, bool fDummy);
@@ -359,17 +359,17 @@ class CTransactionDBCache : public CTransactionDBViewBacked {
     bool AddBlockToCache(const CBlock &block);
     bool DeleteBlockFromCache(const CBlock &block);
     uint256 HasTx(const uint256 &txHash);
-    map<uint256, vector<uint256> > GetTxHashCache(void);
-    bool BatchWrite(const map<uint256, vector<uint256> > &mapTxHashByBlockHashIn);
-    void AddTxHashCache(const uint256 &blockHash, const vector<uint256> &vTxHash);
+    map<uint256, set<uint256> > GetTxHashCache();
+    bool BatchWrite(const map<uint256, set<uint256> > &mapTxHashByBlockHashIn);
+    void AddTxHashCache(const uint256 &blockHash, const set<uint256> &vTxHash);
     bool Flush();
     bool LoadTransaction();
     void Clear();
     Object ToJsonObj() const;
     int GetSize();
     void SetBaseData(CTransactionDBView *pNewBase);
-    const map<uint256, vector<uint256> > &GetCacheMap();
-    void SetCacheMap(const map<uint256, vector<uint256> > &mapCache);
+    const map<uint256, set<uint256> > &GetCacheMap();
+    void SetCacheMap(const map<uint256, set<uint256> > &mapCache);
 };
 
 //class CDelegateDBView {

--- a/src/main.h
+++ b/src/main.h
@@ -46,10 +46,6 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 1024 * 10;
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
-/** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50;
-/** The maximum number of orphan transactions kept in memory */
-static const unsigned int MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE / 100;
 /** The maximum number of orphan blocks kept in memory */
 static const unsigned int MAX_ORPHAN_BLOCKS = 750;
 /** The maximum size of a blk?????.dat file (since 0.8) */

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -597,7 +597,7 @@ Value registercontracttx(const Array& params, bool fHelp)
 
     std::tuple<bool, string> result = CVmlua::CheckScriptSyntax(luaScriptFilePath.c_str());
     bool bOK = std::get<0>(result);
-    if(!bOK)
+    if (!bOK)
         throw JSONRPCError(RPC_INVALID_PARAMS, std::get<1>(result));
 
     FILE* file = fopen(luaScriptFilePath.c_str(), "rb+");
@@ -1775,7 +1775,7 @@ Value listtxcache(const Array& params, bool fHelp) {
                 "\"txcache\"  (string) \n"
                 "\nExamples:\n" + HelpExampleCli("listtxcache", "")+ HelpExampleRpc("listtxcache", ""));
     }
-    const map<uint256, vector<uint256> > &mapTxHashByBlockHash = pTxCacheTip->GetTxHashCache();
+    const map<uint256, set<uint256> > &mapTxHashByBlockHash = pTxCacheTip->GetTxHashCache();
 
     Array retTxHashArray;
     for (auto &item : mapTxHashByBlockHash) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -305,7 +305,7 @@ bool CTransactionDB::GetTxCache(const uint256 &blockHash, vector<uint256> &vHash
     return db.Read(make_pair('h', blockHash), vHashTx);
 }
 
-bool CTransactionDB::BatchWrite(const map<uint256, vector<uint256> > &mapTxHashByBlockHash) {
+bool CTransactionDB::BatchWrite(const map<uint256, set<uint256> > &mapTxHashByBlockHash) {
     CLevelDBBatch batch;
     for (auto &item : mapTxHashByBlockHash) {
         if (item.second.empty()) {
@@ -318,7 +318,7 @@ bool CTransactionDB::BatchWrite(const map<uint256, vector<uint256> > &mapTxHashB
     return db.WriteBatch(batch, true);
 }
 
-bool CTransactionDB::LoadTransaction(map<uint256, vector<uint256> > &mapTxHashByBlockHash) {
+bool CTransactionDB::LoadTransaction(map<uint256, set<uint256> > &mapTxHashByBlockHash) {
     leveldb::Iterator *pcursor = db.NewIterator();
 
     CDataStream ssKeySet(SER_DISK, CLIENT_VERSION);
@@ -336,7 +336,7 @@ bool CTransactionDB::LoadTransaction(map<uint256, vector<uint256> > &mapTxHashBy
             if (chType == 'h') {
                 leveldb::Slice slValue = pcursor->value();
                 CDataStream ssValue(slValue.data(), slValue.data() + slValue.size(), SER_DISK, CLIENT_VERSION);
-                vector<uint256> vTxhash;
+                set<uint256> vTxhash;
                 uint256 blockHash;
                 ssValue >> vTxhash;
                 ssKey >> blockHash;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -99,8 +99,8 @@ class CTransactionDB : public CTransactionDBView {
    public:
     bool SetTxCache(const uint256 &blockHash, const vector<uint256> &hashTxSet);
     bool GetTxCache(const uint256 &hashblock, vector<uint256> &hashTx);
-    bool LoadTransaction(map<uint256, vector<uint256> > &mapTxHashByBlockHash);
-    bool BatchWrite(const map<uint256, vector<uint256> > &mapTxHashByBlockHash);
+    bool LoadTransaction(map<uint256, set<uint256> > &mapTxHashByBlockHash);
+    bool BatchWrite(const map<uint256, set<uint256> > &mapTxHashByBlockHash);
     int64_t GetDbCount() { return db.GetDbCount(); }
 };
 


### PR DESCRIPTION
## 一、TPS 瓶颈定位与优化

### 创建一个区块的基本步骤

1. `CreateNewBlock`，创建新区块，打包交易

```cpp
CBlockTemplate* CreateNewBlock(CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache)
```

2. `CreatePosTx`，创建PoS交易（设置区块的属性、生成区块哈希、交易梅克尔树根等）

```cpp
bool CreatePosTx(const int64_t currentTime, const CAccount &delegate, CAccountViewCache &view, CBlock *pBlock)
```

3. `CreatePosTx`，检测工作量

```cpp
bool CheckWork(CBlock* pblock, CWallet& wallet)
```

### 优化前实测数据

> 机器：PC 上安装 `VMWare` 虚拟机

- 转账发送方在节点钱包里面

```bash
2019-01-08 07:03:31 [miner.cpp:705]MINER: CreateNewBlock tx count:1001 used time :518 ms
2019-01-08 07:03:31 [miner.cpp:632]MINER: CreatePosTx success, used time:3 ms, miner address=wUt89R4bjD3Ca6Vb7mk18oGsVtSTCxJu2q
2019-01-08 07:03:33 [miner.cpp:640]MINER: CheckWork used time:1350 ms
2019-01-08 07:09:13 [miner.cpp:705]MINER: CreateNewBlock tx count:3001 used time :1667 ms
2019-01-08 07:09:13 [miner.cpp:632]MINER: CreatePosTx success, used time:8 ms, miner address=wP64X59EoRmeq2M5GrJ23UVttE9uxnuoFa
2019-01-08 07:09:17 [miner.cpp:640]MINER: CheckWork used time:4176 ms
2019-01-08 07:12:13 [miner.cpp:705]MINER: CreateNewBlock tx count:5001 used time :2943 ms
2019-01-08 07:12:13 [miner.cpp:632]MINER: CreatePosTx success, used time:13 ms, miner address=wNDue1jHcgRSioSDL4o1AzXz3D72gCMkP6
2019-01-08 07:12:20 [miner.cpp:640]MINER: CheckWork used time:7512 ms
2019-01-08 07:14:21 [miner.cpp:705]MINER: CreateNewBlock tx count:7001 used time :4416 ms
2019-01-08 07:14:21 [miner.cpp:632]MINER: CreatePosTx success, used time:19 ms, miner address=wSjMDgKWHC2MzrUamhJtyyR2FTtw8oMUfx
2019-01-08 07:14:33 [miner.cpp:640]MINER: CheckWork used time:12180 ms
```

| 单个区块打包交易数 | `CreateNewBlock` | `CreatePosTx` | `CheckWork` |
| ------------------ | ---------------- | ------------- | ----------- |
| 1000               | 518              | 3             | 1350        |
| 3000               | 1667             | 8             | 4176        |
| 5000               | 2943             | 13            | 7512        |
| 7000               | 4416             | 19            | 12180       |
|                    |                  |               |             |
|                    |                  |               |             |

- 转账发送方与接收方均不在节点钱包里面

```bash
2019-01-08 07:40:34 [miner.cpp:707]MINER: CreateNewBlock tx count:1001 used time :3 ms
2019-01-08 07:40:34 [miner.cpp:634]MINER: CreatePosTx success, used time:9 ms, miner address=wP64X59EoRmeq2M5GrJ23UVttE9uxnuoFa
2019-01-08 07:40:35 [miner.cpp:642]MINER: CheckWork used time:517 ms
2019-01-08 07:44:54 [miner.cpp:707]MINER: CreateNewBlock tx count:3001 used time :2889 ms
2019-01-08 07:44:54 [miner.cpp:634]MINER: CreatePosTx success, used time:11 ms, miner address=wSms4pZnNe7bxjouLxUXQLowc7JqtNps94
2019-01-08 07:44:56 [miner.cpp:642]MINER: CheckWork used time:1728 ms
2019-01-08 07:43:35 [miner.cpp:707]MINER: CreateNewBlock tx count:5001 used time :4478 ms
2019-01-08 07:43:35 [miner.cpp:634]MINER: CreatePosTx success, used time:12 ms, miner address=wQquTWgzNzLtjUV4Du57p9YAEGdKvgXs9t
2019-01-08 07:43:38 [miner.cpp:642]MINER: CheckWork used time:2699 ms
2019-01-08 07:47:36 [miner.cpp:707]MINER: CreateNewBlock tx count:7001 used time :6908 ms
2019-01-08 07:47:36 [miner.cpp:634]MINER: CreatePosTx success, used time:17 ms, miner address=wVTUdfEaeAAVSuXKrmMyqQXH5j5Z9oGmTt
2019-01-08 07:47:40 [miner.cpp:642]MINER: CheckWork used time:4075 ms
```

| 单个区块打包交易数 | `CreateNewBlock` | `CreatePosTx` | `CheckWork` |
| ------------------ | ---------------- | ------------- | ----------- |
| 1000               | 850              | 3             | 517         |
| 3000               | 2889             | 11            | 1728        |
| 5000               | 4478             | 12            | 2699        |
| 7000               | 6908             | 17            | 4075        |
|                    |                  |               |             |
|                    |                  |               |             |

### 瓶颈定位与优化

- `CreateNewBlock` 和 `CheckWork` 随着交易量增加，耗时迅速增加
- 实际上，记账节点处理的交易绝大部分属于第二种：转账发送方与接收方均不在节点钱包里面

#### `CreateNewBlock`

以打包 7000 笔交易为例，`CreateNewBlock()` 耗时约 7000 ms

**调用堆栈：**

`CreateNewBlock() -> GetPriorityTx() -> IsContainTx()`

主要耗时在如下代码

```cpp
uint256 CTransactionDBCache::IsContainTx(const uint256 & txHash) {
	for (auto & item : mapTxHashByBlockHash) {
		vector<uint256>::iterator it = find(item.second.begin(), item.second.end(), txHash);
		if (it != item.second.end()) {
			return item.first;
		}
	}
	uint256 blockHash = pBase->IsContainTx(txHash);
	if (IsInMap(mapTxHashByBlockHash, blockHash)) {
		return std::move(blockHash);
	}
	return std::move(uint256());
}
```

**分析：**

- `map<uint256, vector<uint256> > &mapTxHashByBlockHash` 中，需要对 `vector<uint256>` 进行查询操作，时间复杂度 `O(n)`
- `mapTxHashByBlockHash` 包含最近的 500 个区块

当每个区块包含的交易数目很大时，循环 500 次从 `vector<uint256>` 查询效率过低

**优化：**

修改数据结构 `map<uint256, vector<uint256> > &mapTxHashByBlockHash` 修改成 `map<uint256, set<uint256> > &mapTxHashByBlockHash` 

**提升：**

原来耗时 7000 ms，缩减为 300 ~ 400 ms 左右

####  `CheckWork`

以打包 7000 笔交易为例，`CheckWork()` 耗时 4557 ms，其中 `ConnectBlock()` 耗时 4439 ms

```bash
2019-01-08 08:05:35 [miner.cpp:640]MINER: CheckWork used time: 4557 ms
2019-01-08 08:05:35 [main.cpp:1875]MINER: ConnectTip, ConnectBlock: 4439
```

**调用堆栈：**

`CheckWork() -> ProcessBlock() -> AcceptBlock() -> AddToBlockIndex -> ActivateBestChain -> ConnectTip() -> ConnectBlock()`

主要耗时在如下代码

```cpp
if (pindex->nHeight-SysCfg().GetTxCacheHeight() > 0) {
    CChain chainTemp;
    chainTemp.SetTip(pindex);
    CBlockIndex *pDeleteBlockIndex = chainTemp[pindex->nHeight - SysCfg().GetTxCacheHeight()];
    CBlock deleteBlock;
    if (!ReadBlockFromDisk(deleteBlock, pDeleteBlockIndex))
        return state.Abort(_("Failed to read block"));
    if(!txCache.DeleteBlockFromCache(deleteBlock))
        return state.Abort(_("Connect tip block failed delete block tx to txcache"));
}
```

**优化：**

重构，如下所示

```cpp
if (pindex->nHeight - SysCfg().GetTxCacheHeight() > 0) {
    CBlockIndex *pDeleteBlockIndex = pindex;
    int nCacheHeight = SysCfg().GetTxCacheHeight();
    while (pDeleteBlockIndex && nCacheHeight -- > 0) {
        pDeleteBlockIndex = pDeleteBlockIndex->pprev;
    }
    CBlock deleteBlock;
    if (!ReadBlockFromDisk(deleteBlock, pDeleteBlockIndex))
        return state.Abort(_("Failed to read block"));
    if (!txCache.DeleteBlockFromCache(deleteBlock))
        return state.Abort(_("Connect tip block failed delete block tx to txcache"));
}
```

**提升：**

原来耗时 4557 ms，缩减为 1200 ~ 1300 ms 左右

### 优化汇总

小优化点或修改：

1. 去掉打包时重复判断 `IsContainTx()`，因为从 `mempool` 挑选交易已过滤
2. 修改区块大小，以容纳更多交易数

大优化点：

1. `map<uint256, vector<uint256> > &mapTxHashByBlockHash` 修改 `map<uint256, set<uint256> > &mapTxHashByBlockHash`
2. 重构区块索引定位 `pDeleteBlockIndex`

### 优化后实测数据

```bash
2019-01-14 06:43:51 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 363 ms
2019-01-14 06:43:51 [miner.cpp:625]MINER: CreatePosTx success, used time: 26 ms, miner address=wP64X59EoRmeq2M5GrJ23UVttE9uxnuoFa
2019-01-14 06:43:52 [miner.cpp:633]MINER: CheckWork used time: 1373 ms
2019-01-14 06:46:52 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 371 ms
2019-01-14 06:46:52 [miner.cpp:625]MINER: CreatePosTx success, used time: 41 ms, miner address=wUt89R4bjD3Ca6Vb7mk18oGsVtSTCxJu2q
2019-01-14 06:46:53 [miner.cpp:633]MINER: CheckWork used time: 1343 ms
2019-01-14 06:49:14 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 359 ms
2019-01-14 06:49:14 [miner.cpp:625]MINER: CreatePosTx success, used time: 38 ms, miner address=wSms4pZnNe7bxjouLxUXQLowc7JqtNps94
2019-01-14 06:49:15 [miner.cpp:633]MINER: CheckWork used time: 1295 ms
```

在另外一个时间点，再次测试（系统负载不一样，略有不同）

```bash
2019-01-15 03:41:30 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 367 ms
2019-01-15 03:41:30 [miner.cpp:625]MINER: CreatePosTx success, used time: 43 ms, miner address=wUt89R4bjD3Ca6Vb7mk18oGsVtSTCxJu2q
2019-01-15 03:41:33 [miner.cpp:633]MINER: CheckWork used time: 2337 ms
2019-01-15 03:43:19 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 369 ms
2019-01-15 03:43:19 [miner.cpp:625]MINER: CreatePosTx success, used time: 43 ms, miner address=wSjMDgKWHC2MzrUamhJtyyR2FTtw8oMUfx
2019-01-15 03:43:21 [miner.cpp:633]MINER: CheckWork used time: 2249 ms
2019-01-15 03:46:34 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 374 ms
2019-01-15 03:46:34 [miner.cpp:625]MINER: CreatePosTx success, used time: 42 ms, miner address=wNDue1jHcgRSioSDL4o1AzXz3D72gCMkP6
2019-01-15 03:46:36 [miner.cpp:633]MINER: CheckWork used time: 2302 ms
2019-01-15 03:56:29 [miner.cpp:698]MINER: CreateNewBlock tx count: 10001 used time: 373 ms
2019-01-15 03:56:29 [miner.cpp:625]MINER: CreatePosTx success, used time: 42 ms, miner address=wP64X59EoRmeq2M5GrJ23UVttE9uxnuoFa
2019-01-15 03:56:31 [miner.cpp:633]MINER: CheckWork used time: 2314 ms
```

| 单个区块打包交易数 | `CreateNewBlock` | `CreatePosTx` | `CheckWork` |
| ------------------ | ---------------- | ------------- | ----------- |
| 10000              | 363              | 26            | 1373        |
| 10000              | 371              | 41            | 1343        |
| 10000              | 359              | 38            | 1295        |
| 10000              | 367              | 43            | 2337        |
| 10000              | 374              | 42            | 2302        |
| 10000              | 373              | 42            | 2314        |

## 二、优化效果

> 校验签名耗时约 600 微秒，10000 笔交易校验签名耗时约 6s

- 优化前，打包 7000 笔交易，耗时 11s
- 优化后，打包 10000 笔交易，耗时 2.5s

## 三、结论

因为记账节点需要校验上一个区块，然后自己出块，所以需要确保：`校验快 + 出块时间 < 10s`，这样才能保证出块有足够时间在网络传播，不发生分叉。

目前优化已经达到此要求，`2.5 + 6 < 10`

## 四、理论上限

校验一个交易最耗时部分在于校验签名 `CheckSignScript`，大约 600 微秒（如果是先收到广播交易，由于已经缓存交易签名，大概 3 微秒）

由于校验算法固定，耗时也固定。即使 10s 全部用于校验交易，最多能够校验 `10 x 1000 x 1000 / 600 = 16666.7` 笔交易，加上其他耗时，粗略计算 TPS 上限小于 1667/s

> **后续进一步优化，可以考虑如下方案：**

- 将校验签名使用多线程，当然会带来线程之间同步耗时（能够改进？）
- 签名算法本身是否可以优化？替换签名算法（EOS 修改了签名算法）？

## 五、升级注意事项

### 哪些节点需要升级？

由于修改了 `mapTxHashByBlockHash` 数据结构，进而影响了序列化并存储到 LevelDB 的数据。

- 任何节点（记账节点，非记账节点）升级之后，需要先将区块数据删掉，重新同步数据（重新同步的过程，会将数据按照新的数据格式序列化和反序列化）
- 任何节点都建议升级，因为不仅提升了记账节点的 TPS，同时提升了非记账节点校验区块的速度

### 如何不中断服务升级？

> 记账节点、非记账节点（包括交易所节点、开放节点）可以独立升级，相互不依赖

- 记账节点升级步骤：

1. 新建一个节点，关闭挖矿，同步数据
2. 同步完成，停掉老节点，同时新节点开启挖矿

- 开放节点升级步骤：

1. 删除区块数据，重新同步即可

- 交易所节点

1. 新建一个节点，同步数据
2. 同步完成，停掉老节点
3. 将钱包数据导入新节点，启动服务