### PR TITLE
Contract: rename GetTxAccounts to GetTxRegID

### DIFF
--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -180,10 +180,8 @@ CRegID::CRegID(uint32_t nHeightIn, uint16_t nIndexIn) {
     vRegID.insert(vRegID.end(), BEGIN(nIndexIn), END(nIndexIn));
 }
 string CRegID::ToString() const {
-//  if(!IsEmpty())
-//  return ::HexStr(vRegID);
     if(!IsEmpty())
-      return  strprintf("%d-%d",nHeight,nIndex);
+      return  strprintf("%d-%d", nHeight, nIndex);
     return string(" ");
 }
 CKeyID CRegID::getKeyID(const CAccountViewCache &view)const
@@ -203,7 +201,6 @@ void CRegID::SetRegIDByCompact(const vector<unsigned char> &vIn) {
         clean();
     }
 }
-
 
 bool CBaseTransaction::IsValidHeight(int nCurrHeight, int nTxCacheHeight) const
 {

--- a/src/tx.h
+++ b/src/tx.h
@@ -43,34 +43,34 @@ typedef vector<unsigned char> vector_unsigned_char;
 #define SCRIPT_ID_SIZE (6)
 
 enum TxType {
-	REWARD_TX	= 1,   	//!< reward tx
-	REG_ACCT_TX = 2,  	//!< tx that used to register account
-	COMMON_TX	= 3,    //!< transfer coin from one account to another
-	CONTRACT_TX	= 4,  	//!< contract tx
-	REG_APP_TX	= 5,   	//!< register app
-	DELEGATE_TX = 6,  	//!< delegate tx
-	NULL_TX,          	//!< NULL_TX
+    REWARD_TX   = 1,    //!< reward tx
+    REG_ACCT_TX = 2,    //!< tx that used to register account
+    COMMON_TX   = 3,    //!< transfer coin from one account to another
+    CONTRACT_TX = 4,    //!< contract tx
+    REG_APP_TX  = 5,    //!< register app
+    DELEGATE_TX = 6,    //!< delegate tx
+    NULL_TX,            //!< NULL_TX
 };
 
 /**
- * brief:	kinds of fund type
+ * brief:   kinds of fund type
  */
 enum FundType {
-	FREEDOM = 1,	    //!< FREEDOM
-	REWARD_FUND,     	//!< REWARD_FUND
-	NULL_FUNDTYPE,   	//!< NULL_FUNDTYPE
+    FREEDOM = 1,        //!< FREEDOM
+    REWARD_FUND,        //!< REWARD_FUND
+    NULL_FUNDTYPE,      //!< NULL_FUNDTYPE
 };
 
 enum OperType {
-	ADD_FREE = 1,  		//!< add money to freedom
-	MINUS_FREE, 		//!< minus money from freedom
-	NULL_OPERTYPE,		//!< invalid operate type
+    ADD_FREE = 1,       //!< add money to freedom
+    MINUS_FREE,         //!< minus money from freedom
+    NULL_OPERTYPE,      //!< invalid operate type
 };
 
 enum VoteOperType {
-	ADD_FUND = 1, 		//!< add operate
-	MINUS_FUND = 2, 	//!< minus operate
-	NULL_OPER,			//!< invalid
+    ADD_FUND = 1,       //!< add operate
+    MINUS_FUND = 2,     //!< minus operate
+    NULL_OPER,          //!< invalid
 };
 
 class CNullID {
@@ -84,64 +84,64 @@ typedef boost::variant<CNullID, CRegID, CKeyID, CPubKey> CUserID;
 /*CRegID 是地址激活后，分配的账户ID*/
 class CRegID {
 private:
-	uint32_t nHeight;
-	uint16_t nIndex;
-	mutable vector<unsigned char> vRegID;
-	void SetRegIDByCompact(const vector<unsigned char> &vIn);
-	void SetRegID(string strRegID);
+    uint32_t nHeight;
+    uint16_t nIndex;
+    mutable vector<unsigned char> vRegID;
+    void SetRegIDByCompact(const vector<unsigned char> &vIn);
+    void SetRegID(string strRegID);
 public:
-	friend class CID;
-	CRegID(string strRegID);
-	CRegID(const vector<unsigned char> &vIn) ;
-	CRegID(uint32_t nHeight = 0, uint16_t nIndex = 0);
+    friend class CID;
+    CRegID(string strRegID);
+    CRegID(const vector<unsigned char> &vIn) ;
+    CRegID(uint32_t nHeight = 0, uint16_t nIndex = 0);
 
-	const vector<unsigned char> &GetVec6() const { assert(vRegID.size() ==6); return vRegID; }
-	void SetRegID(const vector<unsigned char> &vIn) ;
+    const vector<unsigned char> &GetVec6() const { assert(vRegID.size() ==6); return vRegID; }
+    void SetRegID(const vector<unsigned char> &vIn) ;
     CKeyID getKeyID(const CAccountViewCache &view)const;
     uint32_t getHight()const { return nHeight;};
 
-	bool operator ==(const CRegID& co) const {
-		return (this->nHeight == co.nHeight && this->nIndex == co.nIndex);
-	}
-	bool operator !=(const CRegID& co) const {
-		return (this->nHeight != co.nHeight || this->nIndex != co.nIndex);
-	}
-	static bool IsSimpleRegIdStr(const string & str);
-	static bool IsRegIdStr(const string & str);
-	static bool GetKeyID(const string & str,CKeyID &keyId);
+    bool operator ==(const CRegID& co) const {
+        return (this->nHeight == co.nHeight && this->nIndex == co.nIndex);
+    }
+    bool operator !=(const CRegID& co) const {
+        return (this->nHeight != co.nHeight || this->nIndex != co.nIndex);
+    }
+    static bool IsSimpleRegIdStr(const string & str);
+    static bool IsRegIdStr(const string & str);
+    static bool GetKeyID(const string & str,CKeyID &keyId);
 
     bool IsEmpty()const{return (nHeight == 0 && nIndex == 0);};
 
     bool clean();
 
-	string ToString() const;
+    string ToString() const;
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(VARINT(nHeight));
-		READWRITE(VARINT(nIndex));
-		if(fRead) {
-			vRegID.clear();
-			vRegID.insert(vRegID.end(), BEGIN(nHeight), END(nHeight));
-			vRegID.insert(vRegID.end(), BEGIN(nIndex), END(nIndex));
-		}
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(VARINT(nHeight));
+        READWRITE(VARINT(nIndex));
+        if(fRead) {
+            vRegID.clear();
+            vRegID.insert(vRegID.end(), BEGIN(nHeight), END(nHeight));
+            vRegID.insert(vRegID.end(), BEGIN(nIndex), END(nIndex));
+        }
+    )
 
 };
 
 /*CID是一个vector 存放CRegID,CKeyID,CPubKey*/
 class CID {
 private:
-	vector_unsigned_char vchData;
+    vector_unsigned_char vchData;
 public:
-	const vector_unsigned_char &GetID() {
-		return vchData;
-	}
-	static const vector_unsigned_char & UserIDToVector(const CUserID &userid)
-	{
-		return CID(userid).GetID();
-	}
-	bool Set(const CRegID &id);
+    const vector_unsigned_char &GetID() {
+        return vchData;
+    }
+    static const vector_unsigned_char & UserIDToVector(const CUserID &userid)
+    {
+        return CID(userid).GetID();
+    }
+    bool Set(const CRegID &id);
     bool Set(const CKeyID &id);
     bool Set(const CPubKey &id);
     bool Set(const CNullID &id);
@@ -150,441 +150,441 @@ public:
     CID(const CUserID &dest) {Set(dest);}
     CUserID GetUserId();
     IMPLEMENT_SERIALIZE
-	(
-		READWRITE(vchData);
-	)
+    (
+        READWRITE(vchData);
+    )
 };
 
 class CIDVisitor: public boost::static_visitor<bool> {
 private:
-	CID *pId;
+    CID *pId;
 public:
-	CIDVisitor(CID *pIdIn) :
-		pId(pIdIn) {
-	}
-	bool operator()(const CRegID &id) const {
-			return pId->Set(id);
-	}
-	bool operator()(const CKeyID &id) const {
-		return pId->Set(id);
-	}
-	bool operator()(const CPubKey &id) const {
-		return pId->Set(id);
-	}
-	bool operator()(const CNullID &no) const {
-		return true;
-	}
+    CIDVisitor(CID *pIdIn) :
+        pId(pIdIn) {
+    }
+    bool operator()(const CRegID &id) const {
+            return pId->Set(id);
+    }
+    bool operator()(const CKeyID &id) const {
+        return pId->Set(id);
+    }
+    bool operator()(const CPubKey &id) const {
+        return pId->Set(id);
+    }
+    bool operator()(const CNullID &no) const {
+        return true;
+    }
 };
 
 class CBaseTransaction {
 protected:
-	static string txTypeArray[7];
+    static string txTypeArray[7];
 public:
-	static uint64_t nMinTxFee;
-	static int64_t nMinRelayTxFee;
-	static const int CURRENT_VERSION = nTxVersion1;
+    static uint64_t nMinTxFee;
+    static int64_t nMinRelayTxFee;
+    static const int CURRENT_VERSION = nTxVersion1;
 
-	unsigned char nTxType;
-	int nVersion;
-	int nValidHeight;
-	uint64_t nRunStep;  //only in memory
-	int nFuelRate;      //only in memory
+    unsigned char nTxType;
+    int nVersion;
+    int nValidHeight;
+    uint64_t nRunStep;  //only in memory
+    int nFuelRate;      //only in memory
 public:
 
-	CBaseTransaction(const CBaseTransaction &other) {
-		*this = other;
-	}
+    CBaseTransaction(const CBaseTransaction &other) {
+        *this = other;
+    }
 
-	CBaseTransaction(int _nVersion, unsigned char _nTxType) :
-			nTxType(_nTxType), nVersion(_nVersion), nValidHeight(0), nRunStep(0), nFuelRate(0){
-	}
+    CBaseTransaction(int _nVersion, unsigned char _nTxType) :
+            nTxType(_nTxType), nVersion(_nVersion), nValidHeight(0), nRunStep(0), nFuelRate(0){
+    }
 
-	CBaseTransaction() :
-			nTxType(COMMON_TX), nVersion(CURRENT_VERSION), nValidHeight(0), nRunStep(0), nFuelRate(0){
-	}
+    CBaseTransaction() :
+            nTxType(COMMON_TX), nVersion(CURRENT_VERSION), nValidHeight(0), nRunStep(0), nFuelRate(0){
+    }
 
-	virtual ~CBaseTransaction() {
-	}
+    virtual ~CBaseTransaction() {
+    }
 
-	virtual unsigned int GetSerializeSize(int nType, int nVersion) const = 0;
+    virtual unsigned int GetSerializeSize(int nType, int nVersion) const = 0;
 
-	virtual uint256 GetHash() const = 0;
+    virtual uint256 GetHash() const = 0;
 
-	virtual const vector_unsigned_char& GetvContract() {
-		return *((vector_unsigned_char*) nullptr);
-	}
+    virtual const vector_unsigned_char& GetvContract() {
+        return *((vector_unsigned_char*) nullptr);
+    }
 
-	virtual const vector_unsigned_char& GetvSigAcountList() {
-		return *((vector_unsigned_char*) nullptr);
-	}
+    virtual const vector_unsigned_char& GetvSigAcountList() {
+        return *((vector_unsigned_char*) nullptr);
+    }
 
-	virtual uint64_t GetFee() const = 0;
+    virtual uint64_t GetFee() const = 0;
 
-	virtual double GetPriority() const = 0;
+    virtual double GetPriority() const = 0;
 
-	virtual uint256 SignatureHash() const = 0;
+    virtual uint256 SignatureHash() const = 0;
 
-	virtual std::shared_ptr<CBaseTransaction> GetNewInstance() = 0;
+    virtual std::shared_ptr<CBaseTransaction> GetNewInstance() = 0;
 
-	virtual string ToString(CAccountViewCache &view) const = 0;
+    virtual string ToString(CAccountViewCache &view) const = 0;
 
-	virtual Object ToJSON(const CAccountViewCache &AccountView) const = 0;
+    virtual Object ToJSON(const CAccountViewCache &AccountView) const = 0;
 
-	virtual bool GetAddress(std::set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB) = 0;
+    virtual bool GetAddress(std::set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB) = 0;
 
-	virtual bool IsValidHeight(int nCurHeight, int nTxCacheHeight) const;
+    virtual bool IsValidHeight(int nCurHeight, int nTxCacheHeight) const;
 
-	bool IsCoinBase() {
-		return (nTxType == REWARD_TX);
-	}
+    bool IsCoinBase() {
+        return (nTxType == REWARD_TX);
+    }
 
-	virtual bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo,
-			int nHeight, CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB) = 0;
+    virtual bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo,
+            int nHeight, CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB) = 0;
 
-	virtual bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo,
-			int nHeight, CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    virtual bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo,
+            int nHeight, CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	virtual bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB) = 0;
+    virtual bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB) = 0;
 
-	virtual uint64_t GetFuel(int nfuelRate);
+    virtual uint64_t GetFuel(int nfuelRate);
 
-	virtual uint64_t GetValue() const = 0;
+    virtual uint64_t GetValue() const = 0;
 
-	int GetFuelRate(CScriptDBViewCache &scriptDB);
+    int GetFuelRate(CScriptDBViewCache &scriptDB);
 };
 
 class CRegisterAccountTx: public CBaseTransaction {
 
 public:
-	mutable CUserID userId;      //pubkey
-	mutable CUserID minerId;     //Miner pubkey
-	int64_t llFees;
-	vector<unsigned char> signature;
+    mutable CUserID userId;      //pubkey
+    mutable CUserID minerId;     //Miner pubkey
+    int64_t llFees;
+    vector<unsigned char> signature;
 
 public:
-	CRegisterAccountTx(const CBaseTransaction *pBaseTx) {
-		assert(REG_ACCT_TX == pBaseTx->nTxType);
-		*this = *(CRegisterAccountTx *) pBaseTx;
-	}
-	CRegisterAccountTx(const CUserID &uId,const CUserID &minerID,int64_t fees,int height) {
-		nTxType = REG_ACCT_TX;
-		llFees = fees;
-		nValidHeight = height;
-		userId = uId;
-		minerId=minerID;
-		signature.clear();
-	}
-	CRegisterAccountTx() {
-		nTxType = REG_ACCT_TX;
-		llFees = 0;
-		nValidHeight = 0;
-	}
+    CRegisterAccountTx(const CBaseTransaction *pBaseTx) {
+        assert(REG_ACCT_TX == pBaseTx->nTxType);
+        *this = *(CRegisterAccountTx *) pBaseTx;
+    }
+    CRegisterAccountTx(const CUserID &uId,const CUserID &minerID,int64_t fees,int height) {
+        nTxType = REG_ACCT_TX;
+        llFees = fees;
+        nValidHeight = height;
+        userId = uId;
+        minerId=minerID;
+        signature.clear();
+    }
+    CRegisterAccountTx() {
+        nTxType = REG_ACCT_TX;
+        llFees = 0;
+        nValidHeight = 0;
+    }
 
-	~CRegisterAccountTx() {
-	}
+    ~CRegisterAccountTx() {
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(VARINT(this->nVersion));
-		nVersion = this->nVersion;
-		READWRITE(VARINT(nValidHeight));
-		CID id(userId);
-		READWRITE(id);
-		CID mMinerid(minerId);
-		READWRITE(mMinerid);
-		if(fRead) {
-			userId = id.GetUserId();
-			minerId = mMinerid.GetUserId();
-		}
-		READWRITE(VARINT(llFees));
-		READWRITE(signature);
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(VARINT(this->nVersion));
+        nVersion = this->nVersion;
+        READWRITE(VARINT(nValidHeight));
+        CID id(userId);
+        READWRITE(id);
+        CID mMinerid(minerId);
+        READWRITE(mMinerid);
+        if(fRead) {
+            userId = id.GetUserId();
+            minerId = mMinerid.GetUserId();
+        }
+        READWRITE(VARINT(llFees));
+        READWRITE(signature);
+    )
 
-	uint64_t GetValue() const {return 0;}
-	uint64_t GetFee() const {
-		return llFees;
-	}
+    uint64_t GetValue() const {return 0;}
+    uint64_t GetFee() const {
+        return llFees;
+    }
 
-	uint256 GetHash() const;
+    uint256 GetHash() const;
 
-	double GetPriority() const {
-		return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
-	}
+    double GetPriority() const {
+        return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+    }
 
-	uint256 SignatureHash() const;
+    uint256 SignatureHash() const;
 
-	std::shared_ptr<CBaseTransaction> GetNewInstance() {
-		return std::make_shared<CRegisterAccountTx>(this);
-	}
+    std::shared_ptr<CBaseTransaction> GetNewInstance() {
+        return std::make_shared<CRegisterAccountTx>(this);
+    }
 
-	bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 
-	string ToString(CAccountViewCache &view) const;
+    string ToString(CAccountViewCache &view) const;
 
-	Object ToJSON(const CAccountViewCache &AccountView) const;
+    Object ToJSON(const CAccountViewCache &AccountView) const;
 
-	bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 };
 
 class CTransaction : public CBaseTransaction {
 public:
-	mutable CUserID srcRegId;                   //src regid
-	mutable CUserID desUserId;                  //user regid or user key id or app regid
-	uint64_t llFees;
-	uint64_t llValues;                          //transfer amount
-	vector_unsigned_char vContract;
-	vector_unsigned_char signature;
+    mutable CUserID srcRegId;                   //src regid
+    mutable CUserID desUserId;                  //user regid or user key id or app regid
+    uint64_t llFees;
+    uint64_t llValues;                          //transfer amount
+    vector_unsigned_char vContract;
+    vector_unsigned_char signature;
 
 public:
-	CTransaction(const CBaseTransaction *pBaseTx) {
-		assert(CONTRACT_TX == pBaseTx->nTxType || COMMON_TX == pBaseTx->nTxType);
-		*this = *(CTransaction *) pBaseTx;
-	}
-	CTransaction(const CUserID& in_UserRegId, CUserID in_desUserId, uint64_t Fee, uint64_t Value, int high, vector_unsigned_char& pContract)
-	{
-		if (in_UserRegId.type() == typeid(CRegID)) {
-			assert(!boost::get<CRegID>(in_UserRegId).IsEmpty());
-		}
-		if (in_desUserId.type() == typeid(CRegID)) {
-			assert(!boost::get<CRegID>(in_desUserId).IsEmpty());
-		}
-		nTxType = CONTRACT_TX;
-		srcRegId = in_UserRegId;
-		desUserId = in_desUserId;
-		vContract = pContract;
-		nValidHeight = high;
-		llFees = Fee;
-		llValues = Value;
-		signature.clear();
-	}
-	CTransaction(const CUserID& in_UserRegId, CUserID in_desUserId, uint64_t Fee, uint64_t Value, int high)
-	{
-		nTxType = COMMON_TX;
-		if (in_UserRegId.type() == typeid(CRegID)) {
-			assert(!boost::get<CRegID>(in_UserRegId).IsEmpty());
-		}
-		if (in_desUserId.type() == typeid(CRegID)) {
-			assert(!boost::get<CRegID>(in_desUserId).IsEmpty());
-		}
-		srcRegId = in_UserRegId;
-		desUserId = in_desUserId;
-		nValidHeight = high;
-		llFees = Fee;
-		llValues = Value;
-		signature.clear();
-	}
-	CTransaction() {
-		nTxType = COMMON_TX;
-		llFees = 0;
-		vContract.clear();
-		nValidHeight = 0;
-		llValues = 0;
-		signature.clear();
-	}
+    CTransaction(const CBaseTransaction *pBaseTx) {
+        assert(CONTRACT_TX == pBaseTx->nTxType || COMMON_TX == pBaseTx->nTxType);
+        *this = *(CTransaction *) pBaseTx;
+    }
+    CTransaction(const CUserID& in_UserRegId, CUserID in_desUserId, uint64_t Fee, uint64_t Value, int high, vector_unsigned_char& pContract)
+    {
+        if (in_UserRegId.type() == typeid(CRegID)) {
+            assert(!boost::get<CRegID>(in_UserRegId).IsEmpty());
+        }
+        if (in_desUserId.type() == typeid(CRegID)) {
+            assert(!boost::get<CRegID>(in_desUserId).IsEmpty());
+        }
+        nTxType = CONTRACT_TX;
+        srcRegId = in_UserRegId;
+        desUserId = in_desUserId;
+        vContract = pContract;
+        nValidHeight = high;
+        llFees = Fee;
+        llValues = Value;
+        signature.clear();
+    }
+    CTransaction(const CUserID& in_UserRegId, CUserID in_desUserId, uint64_t Fee, uint64_t Value, int high)
+    {
+        nTxType = COMMON_TX;
+        if (in_UserRegId.type() == typeid(CRegID)) {
+            assert(!boost::get<CRegID>(in_UserRegId).IsEmpty());
+        }
+        if (in_desUserId.type() == typeid(CRegID)) {
+            assert(!boost::get<CRegID>(in_desUserId).IsEmpty());
+        }
+        srcRegId = in_UserRegId;
+        desUserId = in_desUserId;
+        nValidHeight = high;
+        llFees = Fee;
+        llValues = Value;
+        signature.clear();
+    }
+    CTransaction() {
+        nTxType = COMMON_TX;
+        llFees = 0;
+        vContract.clear();
+        nValidHeight = 0;
+        llValues = 0;
+        signature.clear();
+    }
 
-	~CTransaction() {
+    ~CTransaction() {
 
-	}
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
-			READWRITE(VARINT(this->nVersion));
-			nVersion = this->nVersion;
-			READWRITE(VARINT(nValidHeight));
-			CID srcId(srcRegId);
-			READWRITE(srcId);
-			CID desId(desUserId);
-			READWRITE(desId);
-			READWRITE(VARINT(llFees));
-			READWRITE(VARINT(llValues));
-			READWRITE(vContract);
-			READWRITE(signature);
-			if(fRead) {
-				srcRegId = srcId.GetUserId();
-				desUserId = desId.GetUserId();
-			}
-	)
+    IMPLEMENT_SERIALIZE
+    (
+            READWRITE(VARINT(this->nVersion));
+            nVersion = this->nVersion;
+            READWRITE(VARINT(nValidHeight));
+            CID srcId(srcRegId);
+            READWRITE(srcId);
+            CID desId(desUserId);
+            READWRITE(desId);
+            READWRITE(VARINT(llFees));
+            READWRITE(VARINT(llValues));
+            READWRITE(vContract);
+            READWRITE(signature);
+            if(fRead) {
+                srcRegId = srcId.GetUserId();
+                desUserId = desId.GetUserId();
+            }
+    )
 
-	uint64_t GetValue() const {return llValues;}
-	uint256 GetHash() const;
+    uint64_t GetValue() const {return llValues;}
+    uint256 GetHash() const;
 
-	uint64_t GetFee() const {
-		return llFees;
-	}
+    uint64_t GetFee() const {
+        return llFees;
+    }
 
-	double GetPriority() const {
-		return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
-	}
+    double GetPriority() const {
+        return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+    }
 
-	uint256 SignatureHash() const;
+    uint256 SignatureHash() const;
 
-	std::shared_ptr<CBaseTransaction> GetNewInstance() {
-		return std::make_shared<CTransaction>(this);
-	}
+    std::shared_ptr<CBaseTransaction> GetNewInstance() {
+        return std::make_shared<CTransaction>(this);
+    }
 
-	string ToString(CAccountViewCache &view) const;
+    string ToString(CAccountViewCache &view) const;
 
-	Object ToJSON(const CAccountViewCache &AccountView) const;
+    Object ToJSON(const CAccountViewCache &AccountView) const;
 
-	bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 
-	const vector_unsigned_char& GetvContract() {
-		return vContract;
-	}
+    const vector_unsigned_char& GetvContract() {
+        return vContract;
+    }
 
-	bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 
 };
 
 class CRewardTransaction: public CBaseTransaction {
 
 public:
-	mutable CUserID account;   // in genesis block are pubkey, otherwise are account id
-	uint64_t rewardValue;
-	int nHeight;
+    mutable CUserID account;   // in genesis block are pubkey, otherwise are account id
+    uint64_t rewardValue;
+    int nHeight;
 public:
-	CRewardTransaction(const CBaseTransaction *pBaseTx) {
-		assert(REWARD_TX == pBaseTx->nTxType);
-		*this = *(CRewardTransaction*) pBaseTx;
-	}
+    CRewardTransaction(const CBaseTransaction *pBaseTx) {
+        assert(REWARD_TX == pBaseTx->nTxType);
+        *this = *(CRewardTransaction*) pBaseTx;
+    }
 
-	CRewardTransaction(const vector_unsigned_char &accountIn, const uint64_t rewardValueIn, const int _nHeight) {
-		nTxType = REWARD_TX;
-		if (accountIn.size() > 6) {
-			account = CPubKey(accountIn);
-		} else {
-			account = CRegID(accountIn);
-		}
-		rewardValue = rewardValueIn;
-		nHeight = _nHeight;
-	}
+    CRewardTransaction(const vector_unsigned_char &accountIn, const uint64_t rewardValueIn, const int _nHeight) {
+        nTxType = REWARD_TX;
+        if (accountIn.size() > 6) {
+            account = CPubKey(accountIn);
+        } else {
+            account = CRegID(accountIn);
+        }
+        rewardValue = rewardValueIn;
+        nHeight = _nHeight;
+    }
 
-	CRewardTransaction() {
-		nTxType = REWARD_TX;
-		rewardValue = 0;
-		nHeight = 0;
-	}
+    CRewardTransaction() {
+        nTxType = REWARD_TX;
+        rewardValue = 0;
+        nHeight = 0;
+    }
 
-	~CRewardTransaction() {
-	}
+    ~CRewardTransaction() {
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(VARINT(this->nVersion));
-		nVersion = this->nVersion;
-		CID acctId(account);
-		READWRITE(acctId);
-		if(fRead) {
-			account = acctId.GetUserId();
-		}
-		READWRITE(VARINT(rewardValue));
-		READWRITE(VARINT(nHeight));
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(VARINT(this->nVersion));
+        nVersion = this->nVersion;
+        CID acctId(account);
+        READWRITE(acctId);
+        if(fRead) {
+            account = acctId.GetUserId();
+        }
+        READWRITE(VARINT(rewardValue));
+        READWRITE(VARINT(nHeight));
+    )
 
-	uint64_t GetValue() const {return rewardValue;}
-	uint256 GetHash() const;
+    uint64_t GetValue() const {return rewardValue;}
+    uint256 GetHash() const;
 
-	std::shared_ptr<CBaseTransaction> GetNewInstance() {
-		return std::make_shared<CRewardTransaction>(this);
-	}
+    std::shared_ptr<CBaseTransaction> GetNewInstance() {
+        return std::make_shared<CRewardTransaction>(this);
+    }
 
-	uint256 SignatureHash() const;
+    uint256 SignatureHash() const;
 
-	uint64_t GetFee() const {
-		return 0;
-	}
+    uint64_t GetFee() const {
+        return 0;
+    }
 
-	double GetPriority() const {
-		return 0.0f;
-	}
+    double GetPriority() const {
+        return 0.0f;
+    }
 
-	string ToString(CAccountViewCache &view) const;
+    string ToString(CAccountViewCache &view) const;
 
-	Object ToJSON(const CAccountViewCache &AccountView) const;
+    Object ToJSON(const CAccountViewCache &AccountView) const;
 
-	bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 
-	bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 };
 
 class CRegisterAppTx: public CBaseTransaction {
 
 public:
-	mutable CUserID regAcctId;         //regid
-	vector_unsigned_char script;       //script content
-	uint64_t llFees;
-	vector_unsigned_char signature;
+    mutable CUserID regAcctId;         //regid
+    vector_unsigned_char script;       //script content
+    uint64_t llFees;
+    vector_unsigned_char signature;
 public:
-	CRegisterAppTx(const CBaseTransaction *pBaseTx) {
-		assert(REG_APP_TX == pBaseTx->nTxType);
-		*this = *(CRegisterAppTx*) pBaseTx;
-	}
+    CRegisterAppTx(const CBaseTransaction *pBaseTx) {
+        assert(REG_APP_TX == pBaseTx->nTxType);
+        *this = *(CRegisterAppTx*) pBaseTx;
+    }
 
-	CRegisterAppTx() {
-		nTxType = REG_APP_TX;
-		llFees = 0;
-		nValidHeight = 0;
-	}
+    CRegisterAppTx() {
+        nTxType = REG_APP_TX;
+        llFees = 0;
+        nValidHeight = 0;
+    }
 
-	~CRegisterAppTx() {
-	}
+    ~CRegisterAppTx() {
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(VARINT(this->nVersion));
-		nVersion = this->nVersion;
-		READWRITE(VARINT(nValidHeight));
-		CID regId(regAcctId);
-		READWRITE(regId);
-		if(fRead) {
-			regAcctId = regId.GetUserId();
-		}
-		READWRITE(script);
-		READWRITE(VARINT(llFees));
-		READWRITE(signature);
-	)
-	uint64_t GetValue() const {return 0;}
-	uint256 GetHash() const;
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(VARINT(this->nVersion));
+        nVersion = this->nVersion;
+        READWRITE(VARINT(nValidHeight));
+        CID regId(regAcctId);
+        READWRITE(regId);
+        if(fRead) {
+            regAcctId = regId.GetUserId();
+        }
+        READWRITE(script);
+        READWRITE(VARINT(llFees));
+        READWRITE(signature);
+    )
+    uint64_t GetValue() const {return 0;}
+    uint256 GetHash() const;
 
-	std::shared_ptr<CBaseTransaction> GetNewInstance() {
-		return std::make_shared<CRegisterAppTx>(this);
-	}
+    std::shared_ptr<CBaseTransaction> GetNewInstance() {
+        return std::make_shared<CRegisterAppTx>(this);
+    }
 
-	uint256 SignatureHash() const;
+    uint256 SignatureHash() const;
 
-	uint64_t GetFee() const {
-		return llFees;
-	}
+    uint64_t GetFee() const {
+        return llFees;
+    }
 
-	double GetPriority() const {
-		return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
-	}
+    double GetPriority() const {
+        return llFees / GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+    }
 
-	string ToString(CAccountViewCache &view) const;
+    string ToString(CAccountViewCache &view) const;
 
-	Object ToJSON(const CAccountViewCache &AccountView) const;
+    Object ToJSON(const CAccountViewCache &AccountView) const;
 
-	bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool GetAddress(set<CKeyID> &vAddr, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 
-	bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
-			CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
+    bool UndoExecuteTx(int nIndex, CAccountViewCache &view, CValidationState &state, CTxUndo &txundo, int nHeight,
+            CTransactionDBCache &txCache, CScriptDBViewCache &scriptDB);
 
-	bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
+    bool CheckTransaction(CValidationState &state, CAccountViewCache &view, CScriptDBViewCache &scriptDB);
 };
 
 class CDelegateTransaction: public CBaseTransaction {
@@ -687,70 +687,70 @@ public:
 class CVoteFund {
 public:
     CPubKey pubKey;                 //!< delegates public key
-	uint64_t value;					//!< amount of vote
+    uint64_t value;                 //!< amount of vote
 
 public:
-	CVoteFund() {
-		value = 0;
-		pubKey = CPubKey();
-	}
-	CVoteFund(uint64_t _value) {
-		value = _value;
-		pubKey = CPubKey();
-	}
-	CVoteFund(uint64_t _value, CPubKey _pubKey) {
-		value = _value;
-		pubKey = _pubKey;
-	}
-	CVoteFund(const CVoteFund &fund) {
-		value = fund.value;
-		pubKey = fund.pubKey;
-	}
-	CVoteFund & operator =(const CVoteFund &fund) {
-		if (this == &fund) {
-			return *this;
-		}
-		this->value = fund.value;
-		this->pubKey = fund.pubKey;
-		return *this;
-	}
-	~CVoteFund() {
-	}
+    CVoteFund() {
+        value = 0;
+        pubKey = CPubKey();
+    }
+    CVoteFund(uint64_t _value) {
+        value = _value;
+        pubKey = CPubKey();
+    }
+    CVoteFund(uint64_t _value, CPubKey _pubKey) {
+        value = _value;
+        pubKey = _pubKey;
+    }
+    CVoteFund(const CVoteFund &fund) {
+        value = fund.value;
+        pubKey = fund.pubKey;
+    }
+    CVoteFund & operator =(const CVoteFund &fund) {
+        if (this == &fund) {
+            return *this;
+        }
+        this->value = fund.value;
+        this->pubKey = fund.pubKey;
+        return *this;
+    }
+    ~CVoteFund() {
+    }
 
-	uint256 GetHash() const {
-		CHashWriter ss(SER_GETHASH, 0);
-		ss << VARINT(value) << pubKey;
-		return ss.GetHash();
-	}
+    uint256 GetHash() const {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << VARINT(value) << pubKey;
+        return ss.GetHash();
+    }
 
-	friend bool operator <(const CVoteFund &fa, const CVoteFund &fb) {
-		if (fa.value <= fb.value)
-			return true;
-		else
-			return false;
-	}
+    friend bool operator <(const CVoteFund &fa, const CVoteFund &fb) {
+        if (fa.value <= fb.value)
+            return true;
+        else
+            return false;
+    }
 
-	friend bool operator >(const CVoteFund &fa, const CVoteFund &fb) {
-		return !operator<(fa, fb);
-	}
+    friend bool operator >(const CVoteFund &fa, const CVoteFund &fb) {
+        return !operator<(fa, fb);
+    }
 
-	friend bool operator ==(const CVoteFund &fa, const CVoteFund &fb) {
+    friend bool operator ==(const CVoteFund &fa, const CVoteFund &fb) {
         if (fa.pubKey != fb.pubKey)
-			return false;
+            return false;
         if (fa.value != fb.value)
-			return false;
-		return true;
-	}
+            return false;
+        return true;
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
+    IMPLEMENT_SERIALIZE
+    (
         READWRITE(pubKey);
-		READWRITE(VARINT(value));
+        READWRITE(VARINT(value));
 
-	)
+    )
 
-	string ToString(bool isAddress=false) const {
-	    string str("");
+    string ToString(bool isAddress=false) const {
+        string str("");
         str += "pubKey:";
         if(isAddress) {
             str += pubKey.GetKeyID().ToAddress();
@@ -761,333 +761,333 @@ public:
         str += strprintf("%s", value);
         str += "\n";
         return str;
-	}
+    }
 
-	Object ToJson(bool isAddress=false) const;
+    Object ToJson(bool isAddress=false) const;
 };
 
 class CScriptDBOperLog {
 public:
-	vector<unsigned char> vKey;
-	vector<unsigned char> vValue;
+    vector<unsigned char> vKey;
+    vector<unsigned char> vValue;
 
-	CScriptDBOperLog (const vector<unsigned char> &vKeyIn, const vector<unsigned char> &vValueIn) {
-		vKey = vKeyIn;
-		vValue = vValueIn;
-	}
+    CScriptDBOperLog (const vector<unsigned char> &vKeyIn, const vector<unsigned char> &vValueIn) {
+        vKey = vKeyIn;
+        vValue = vValueIn;
+    }
 
-	CScriptDBOperLog() {
-		vKey.clear();
-		vValue.clear();
-	}
+    CScriptDBOperLog() {
+        vKey.clear();
+        vValue.clear();
+    }
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(vKey);
-		READWRITE(vValue);
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(vKey);
+        READWRITE(vValue);
+    )
 
-	string ToString() const {
-		string str("");
-		str += "vKey:";
-		str += HexStr(vKey);
-		str += "\n";
-		str +="vValue:";
-		str += HexStr(vValue);
-		str += "\n";
-		return str;
-	}
+    string ToString() const {
+        string str("");
+        str += "vKey:";
+        str += HexStr(vKey);
+        str += "\n";
+        str +="vValue:";
+        str += HexStr(vValue);
+        str += "\n";
+        return str;
+    }
 
-	friend bool operator<(const CScriptDBOperLog &log1, const CScriptDBOperLog &log2) {
-		return log1.vKey < log2.vKey;
-	}
+    friend bool operator<(const CScriptDBOperLog &log1, const CScriptDBOperLog &log2) {
+        return log1.vKey < log2.vKey;
+    }
 };
 
 class COperVoteFund {
 public:
     static string voteOperTypeArray[3];
 public:
-	unsigned char operType;  		//!<1:ADD_FUND 2:MINUS_FUND
-	CVoteFund fund;
+    unsigned char operType;         //!<1:ADD_FUND 2:MINUS_FUND
+    CVoteFund fund;
 
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(operType);
-		READWRITE(fund);
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(operType);
+        READWRITE(fund);
+    )
 public:
-	COperVoteFund() {
-		operType = NULL_OPER;
-	}
+    COperVoteFund() {
+        operType = NULL_OPER;
+    }
 
-	COperVoteFund(unsigned char nType, const CVoteFund& operFund) {
-		operType = nType;
-		fund = operFund;
-	}
+    COperVoteFund(unsigned char nType, const CVoteFund& operFund) {
+        operType = nType;
+        fund = operFund;
+    }
 
-	string ToString(bool isAddress=false) const;
+    string ToString(bool isAddress=false) const;
 
-	Object ToJson(bool isAddress=false) const;
+    Object ToJson(bool isAddress=false) const;
 
 
 };
 
 class CTxUndo {
 public:
-	uint256 txHash;
-	vector<CAccountLog> vAccountLog;
-	vector<CScriptDBOperLog> vScriptOperLog;
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(txHash);
-		READWRITE(vAccountLog);
-		READWRITE(vScriptOperLog);
-	)
+    uint256 txHash;
+    vector<CAccountLog> vAccountLog;
+    vector<CScriptDBOperLog> vScriptOperLog;
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(txHash);
+        READWRITE(vAccountLog);
+        READWRITE(vScriptOperLog);
+    )
 
 public:
-	bool GetAccountOperLog(const CKeyID &keyId, CAccountLog &accountLog);
-	void Clear() {
-		txHash = uint256();
-		vAccountLog.clear();
-		vScriptOperLog.clear();
-	}
-	string ToString() const;
+    bool GetAccountOperLog(const CKeyID &keyId, CAccountLog &accountLog);
+    void Clear() {
+        txHash = uint256();
+        vAccountLog.clear();
+        vScriptOperLog.clear();
+    }
+    string ToString() const;
 };
 
 class CAccount {
 public:
-	CRegID regID;
-	CKeyID keyID;											//!< keyID of the account
-	CPubKey PublicKey;										//!< public key of the account
-	CPubKey MinerPKey;									    //!< public key of the account for miner
-	uint64_t llValues;										//!< total money
-	int nHeight;                                            //!< update height
-	vector<CVoteFund> voteFunds;                            //!< delegate votes order by vote value
-	uint64_t llVotes;                                       //!< votes received
+    CRegID regID;
+    CKeyID keyID;                                           //!< keyID of the account
+    CPubKey PublicKey;                                      //!< public key of the account
+    CPubKey MinerPKey;                                      //!< public key of the account for miner
+    uint64_t llValues;                                      //!< total money
+    int nHeight;                                            //!< update height
+    vector<CVoteFund> voteFunds;                            //!< delegate votes order by vote value
+    uint64_t llVotes;                                       //!< votes received
 public :
-	/**
-	 * @brief operate account
-	 * @param type:	operate type
-	 * @param fund
-	 * @param nHeight:	the height that block connected into chain
-	 * @param pscriptID
-	 * @param bCheckAuthorized
-	 * @return if operate successfully return ture,otherwise return false
-	 */
-	bool OperateAccount(OperType type, const uint64_t &values,const int nCurHeight);
+    /**
+     * @brief operate account
+     * @param type: operate type
+     * @param fund
+     * @param nHeight:  the height that block connected into chain
+     * @param pscriptID
+     * @param bCheckAuthorized
+     * @return if operate successfully return ture,otherwise return false
+     */
+    bool OperateAccount(OperType type, const uint64_t &values,const int nCurHeight);
 
-	bool UndoOperateAccount(const CAccountLog & accountLog);
+    bool UndoOperateAccount(const CAccountLog & accountLog);
 
-	bool DealDelegateVote (vector<COperVoteFund> & operVoteFunds, const int nCurHeight);
+    bool DealDelegateVote (vector<COperVoteFund> & operVoteFunds, const int nCurHeight);
 
-	bool OperateVote(VoteOperType type, const uint64_t & values);
+    bool OperateVote(VoteOperType type, const uint64_t & values);
 public:
-	CAccount(CKeyID &keyId, CPubKey &pubKey) :
-			keyID(keyId), PublicKey(pubKey) {
-		llValues = 0;
-		MinerPKey =  CPubKey();
-		nHeight = 0;
-		regID.clean();
-		voteFunds.clear();
-		llVotes = 0;
-	}
-	CAccount() :keyID(uint160()), llValues(0) {
-		PublicKey = CPubKey();
-		MinerPKey =  CPubKey();
-		nHeight = 0;
-		regID.clean();
-		voteFunds.clear();
-		llVotes = 0;
-	}
-	CAccount(const CAccount & other) {
-		this->regID = other.regID;
-		this->keyID = other.keyID;
-		this->PublicKey = other.PublicKey;
-		this->MinerPKey = other.MinerPKey;
-		this->llValues = other.llValues;
-		this->nHeight = other.nHeight;
-		this->voteFunds = other.voteFunds;
-		this->llVotes = other.llVotes;
-	}
-	CAccount &operator=(const CAccount & other) {
-		if(this == &other)
-			return *this;
-		this->regID = other.regID;
-		this->keyID = other.keyID;
-		this->PublicKey = other.PublicKey;
-		this->MinerPKey = other.MinerPKey;
-		this->llValues = other.llValues;
-		this->nHeight = other.nHeight;
-		this->voteFunds = other.voteFunds;
-		this->llVotes = other.llVotes;
-		return *this;
-	}
-	std::shared_ptr<CAccount> GetNewInstance() const{
-		return std::make_shared<CAccount>(*this);
-	}
+    CAccount(CKeyID &keyId, CPubKey &pubKey) :
+            keyID(keyId), PublicKey(pubKey) {
+        llValues = 0;
+        MinerPKey =  CPubKey();
+        nHeight = 0;
+        regID.clean();
+        voteFunds.clear();
+        llVotes = 0;
+    }
+    CAccount() :keyID(uint160()), llValues(0) {
+        PublicKey = CPubKey();
+        MinerPKey =  CPubKey();
+        nHeight = 0;
+        regID.clean();
+        voteFunds.clear();
+        llVotes = 0;
+    }
+    CAccount(const CAccount & other) {
+        this->regID = other.regID;
+        this->keyID = other.keyID;
+        this->PublicKey = other.PublicKey;
+        this->MinerPKey = other.MinerPKey;
+        this->llValues = other.llValues;
+        this->nHeight = other.nHeight;
+        this->voteFunds = other.voteFunds;
+        this->llVotes = other.llVotes;
+    }
+    CAccount &operator=(const CAccount & other) {
+        if(this == &other)
+            return *this;
+        this->regID = other.regID;
+        this->keyID = other.keyID;
+        this->PublicKey = other.PublicKey;
+        this->MinerPKey = other.MinerPKey;
+        this->llValues = other.llValues;
+        this->nHeight = other.nHeight;
+        this->voteFunds = other.voteFunds;
+        this->llVotes = other.llVotes;
+        return *this;
+    }
+    std::shared_ptr<CAccount> GetNewInstance() const{
+        return std::make_shared<CAccount>(*this);
+    }
 
-	bool IsMiner(int nCurHeight) {
-//		if(nCurHeight < 2*SysCfg().GetIntervalPos())
-//			return true;
-//		return nCoinDay >= llValues * SysCfg().GetIntervalPos();
-	    return true;
+    bool IsMiner(int nCurHeight) {
+//      if(nCurHeight < 2*SysCfg().GetIntervalPos())
+//          return true;
+//      return nCoinDay >= llValues * SysCfg().GetIntervalPos();
+        return true;
 
-	}
-	bool IsRegister() const {
-		return (PublicKey.IsFullyValid() && PublicKey.GetKeyID() == keyID);
-	}
-	bool SetRegId(const CRegID &regID){this->regID = regID;return true;};
-	bool GetRegId(CRegID &regID)const {regID = this->regID;return !regID.IsEmpty();};
-	uint64_t GetRawBalance();
-	uint64_t GetTotalBalance();
-	uint64_t GetFrozenBalance();
-//	void ClearAccPos(int nCurHeight);
-	uint64_t GetAccountProfit(int prevBlockHeight);
-	string ToString(bool isAddress = false) const;
-	Object ToJsonObj(bool isAddress = false) const;
-	bool IsEmptyValue() const {
-		return !(llValues > 0);
-	}
-	uint256 GetHash(){
-		CHashWriter ss(SER_GETHASH, 0);
-		ss << regID << keyID << PublicKey << MinerPKey << VARINT(llValues)
-		   << VARINT(nHeight) << voteFunds << llVotes;
-		return ss.GetHash();
-	}
-	uint64_t GetMaxCoinDay(int nCurHeight) {
-		return llValues * SysCfg().GetMaxDay();
-	}
+    }
+    bool IsRegister() const {
+        return (PublicKey.IsFullyValid() && PublicKey.GetKeyID() == keyID);
+    }
+    bool SetRegId(const CRegID &regID){this->regID = regID;return true;};
+    bool GetRegId(CRegID &regID)const {regID = this->regID;return !regID.IsEmpty();};
+    uint64_t GetRawBalance();
+    uint64_t GetTotalBalance();
+    uint64_t GetFrozenBalance();
+//  void ClearAccPos(int nCurHeight);
+    uint64_t GetAccountProfit(int prevBlockHeight);
+    string ToString(bool isAddress = false) const;
+    Object ToJsonObj(bool isAddress = false) const;
+    bool IsEmptyValue() const {
+        return !(llValues > 0);
+    }
+    uint256 GetHash(){
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << regID << keyID << PublicKey << MinerPKey << VARINT(llValues)
+           << VARINT(nHeight) << voteFunds << llVotes;
+        return ss.GetHash();
+    }
+    uint64_t GetMaxCoinDay(int nCurHeight) {
+        return llValues * SysCfg().GetMaxDay();
+    }
 
-	bool UpDateAccountPos(int nCurHeight);
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(regID);
-		READWRITE(keyID);
-		READWRITE(PublicKey);
-		READWRITE(MinerPKey);
-		READWRITE(VARINT(llValues));
-		READWRITE(VARINT(nHeight));
-		READWRITE(voteFunds);
-		READWRITE(llVotes);
-	)
+    bool UpDateAccountPos(int nCurHeight);
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(regID);
+        READWRITE(keyID);
+        READWRITE(PublicKey);
+        READWRITE(MinerPKey);
+        READWRITE(VARINT(llValues));
+        READWRITE(VARINT(nHeight));
+        READWRITE(voteFunds);
+        READWRITE(llVotes);
+    )
 
-	uint64_t GetReceiveVotes() const {
-	    return llVotes;
-	}
+    uint64_t GetReceiveVotes() const {
+        return llVotes;
+    }
 private:
-	bool IsMoneyOverflow(uint64_t nAddMoney);
+    bool IsMoneyOverflow(uint64_t nAddMoney);
 };
 
 
 class CAccountLog {
 public:
-	CKeyID keyID;
-	uint64_t llValues;										//!< freedom money which coinage greater than 30 days
-	int nHeight;                                            //!< update height
+    CKeyID keyID;
+    uint64_t llValues;                                      //!< freedom money which coinage greater than 30 days
+    int nHeight;                                            //!< update height
     vector<CVoteFund> voteFunds;                            //!< delegate votes
     uint64_t llVotes;                                       //!< votes received
-	IMPLEMENT_SERIALIZE
-	(
-		READWRITE(keyID);
-		READWRITE(VARINT(llValues));
-		READWRITE(VARINT(nHeight));
-		READWRITE(voteFunds);
-		READWRITE(llVotes);
-	)
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(keyID);
+        READWRITE(VARINT(llValues));
+        READWRITE(VARINT(nHeight));
+        READWRITE(voteFunds);
+        READWRITE(llVotes);
+    )
 public:
-	CAccountLog(const CAccount &acct) {
-		keyID = acct.keyID;
-		llValues = acct.llValues;
-		nHeight = acct.nHeight;
-		voteFunds = acct.voteFunds;
-		llVotes = acct.llVotes;
-	}
-	CAccountLog(CKeyID &keyId) {
-		keyID = keyId;
-		llValues = 0;
-		nHeight = 0;
-		llVotes = 0;
-	}
-	CAccountLog() {
-		keyID = uint160();
-		llValues = 0;
-		nHeight = 0;
-		voteFunds.clear();
-		llVotes = 0;
-	}
-	void SetValue(const CAccount &acct) {
-		keyID = acct.keyID;
-		llValues = acct.llValues;
-		nHeight = acct.nHeight;
-		llVotes = acct.llVotes;
-		voteFunds = acct.voteFunds;
-	}
-	string ToString() const;
+    CAccountLog(const CAccount &acct) {
+        keyID = acct.keyID;
+        llValues = acct.llValues;
+        nHeight = acct.nHeight;
+        voteFunds = acct.voteFunds;
+        llVotes = acct.llVotes;
+    }
+    CAccountLog(CKeyID &keyId) {
+        keyID = keyId;
+        llValues = 0;
+        nHeight = 0;
+        llVotes = 0;
+    }
+    CAccountLog() {
+        keyID = uint160();
+        llValues = 0;
+        nHeight = 0;
+        voteFunds.clear();
+        llVotes = 0;
+    }
+    void SetValue(const CAccount &acct) {
+        keyID = acct.keyID;
+        llValues = acct.llValues;
+        nHeight = acct.nHeight;
+        llVotes = acct.llVotes;
+        voteFunds = acct.voteFunds;
+    }
+    string ToString() const;
 };
 inline unsigned int GetSerializeSize(const std::shared_ptr<CBaseTransaction> &pa, int nType, int nVersion) {
-	return pa->GetSerializeSize(nType, nVersion) + 1;
+    return pa->GetSerializeSize(nType, nVersion) + 1;
 }
 
 template<typename Stream>
 void Serialize(Stream& os, const std::shared_ptr<CBaseTransaction> &pa, int nType, int nVersion) {
-	unsigned char ntxType = pa->nTxType;
-	Serialize(os, ntxType, nType, nVersion);
-	if (pa->nTxType == REG_ACCT_TX) {
-		Serialize(os, *((CRegisterAccountTx *) (pa.get())), nType, nVersion);
-	}
-	else if (pa->nTxType == COMMON_TX) {
-		Serialize(os, *((CTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (pa->nTxType == CONTRACT_TX) {
-		Serialize(os, *((CTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (pa->nTxType == REWARD_TX) {
-		Serialize(os, *((CRewardTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (pa->nTxType == REG_APP_TX) {
-		Serialize(os, *((CRegisterAppTx *) (pa.get())), nType, nVersion);
-	}
-	else if (pa->nTxType == DELEGATE_TX) {
-	    Serialize(os, *((CDelegateTransaction *) (pa.get())), nType, nVersion);
-	}
-	else {
-		throw ios_base::failure("seiralize tx type value error, must be ranger(1...6)");
-	}
+    unsigned char ntxType = pa->nTxType;
+    Serialize(os, ntxType, nType, nVersion);
+    if (pa->nTxType == REG_ACCT_TX) {
+        Serialize(os, *((CRegisterAccountTx *) (pa.get())), nType, nVersion);
+    }
+    else if (pa->nTxType == COMMON_TX) {
+        Serialize(os, *((CTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (pa->nTxType == CONTRACT_TX) {
+        Serialize(os, *((CTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (pa->nTxType == REWARD_TX) {
+        Serialize(os, *((CRewardTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (pa->nTxType == REG_APP_TX) {
+        Serialize(os, *((CRegisterAppTx *) (pa.get())), nType, nVersion);
+    }
+    else if (pa->nTxType == DELEGATE_TX) {
+        Serialize(os, *((CDelegateTransaction *) (pa.get())), nType, nVersion);
+    }
+    else {
+        throw ios_base::failure("seiralize tx type value error, must be ranger(1...6)");
+    }
 
 }
 
 template<typename Stream>
 void Unserialize(Stream& is, std::shared_ptr<CBaseTransaction> &pa, int nType, int nVersion) {
-	char nTxType;
-	is.read((char*) &(nTxType), sizeof(nTxType));
-	if (nTxType == REG_ACCT_TX) {
-		pa = std::make_shared<CRegisterAccountTx>();
-		Unserialize(is, *((CRegisterAccountTx *) (pa.get())), nType, nVersion);
-	}
-	else if (nTxType == COMMON_TX) {
-		pa = std::make_shared<CTransaction>();
-		Unserialize(is, *((CTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (nTxType == CONTRACT_TX) {
-		pa = std::make_shared<CTransaction>();
-		Unserialize(is, *((CTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (nTxType == REWARD_TX) {
-		pa = std::make_shared<CRewardTransaction>();
-		Unserialize(is, *((CRewardTransaction *) (pa.get())), nType, nVersion);
-	}
-	else if (nTxType == REG_APP_TX) {
-		pa = std::make_shared<CRegisterAppTx>();
-		Unserialize(is, *((CRegisterAppTx *) (pa.get())), nType, nVersion);
-	}
-	else if (nTxType == DELEGATE_TX) {
+    char nTxType;
+    is.read((char*) &(nTxType), sizeof(nTxType));
+    if (nTxType == REG_ACCT_TX) {
+        pa = std::make_shared<CRegisterAccountTx>();
+        Unserialize(is, *((CRegisterAccountTx *) (pa.get())), nType, nVersion);
+    }
+    else if (nTxType == COMMON_TX) {
+        pa = std::make_shared<CTransaction>();
+        Unserialize(is, *((CTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (nTxType == CONTRACT_TX) {
+        pa = std::make_shared<CTransaction>();
+        Unserialize(is, *((CTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (nTxType == REWARD_TX) {
+        pa = std::make_shared<CRewardTransaction>();
+        Unserialize(is, *((CRewardTransaction *) (pa.get())), nType, nVersion);
+    }
+    else if (nTxType == REG_APP_TX) {
+        pa = std::make_shared<CRegisterAppTx>();
+        Unserialize(is, *((CRegisterAppTx *) (pa.get())), nType, nVersion);
+    }
+    else if (nTxType == DELEGATE_TX) {
         pa = std::make_shared<CDelegateTransaction>();
         Unserialize(is, *((CDelegateTransaction *) (pa.get())), nType, nVersion);
-	}
-	else {
-		throw ios_base::failure("unseiralize tx type value error, must be ranger(1...6)");
-	}
-	pa->nTxType = nTxType;
+    }
+    else {
+        throw ios_base::failure("unseiralize tx type value error, must be ranger(1...6)");
+    }
+    pa->nTxType = nTxType;
 }
 
 

--- a/src/vm/lmylib.cpp
+++ b/src/vm/lmylib.cpp
@@ -32,55 +32,55 @@
 
 #if 0
 static void setfield(lua_State *L,char * key,double value){
-	 //默认栈顶是table
-	lua_pushstring(L,key);
-	lua_pushnumber(L,value);
-	lua_settable(L,-3);	//将这一对键值设成元素
+     //默认栈顶是table
+    lua_pushstring(L,key);
+    lua_pushnumber(L,value);
+    lua_settable(L,-3); //将这一对键值设成元素
 }
 static void stackDump(lua_State *L){
-	int i;
-	int top = lua_gettop(L);
-//	int top = 20;//debug
-	for(i = 0;i < top;i++){
-		int t = lua_type(L,-1 - i);
-		switch(t){
-		case LUA_TSTRING:
-			LogPrint("vm","%d str =%s\n", i, lua_tostring(L,-1 - i));
-			break;
-		case LUA_TBOOLEAN:
-			LogPrint("vm","boolean =%d\n",lua_toboolean(L,-1 - i));
-			break;
-		case LUA_TNUMBER:
-			LogPrint("vm","number =%d\n",lua_tonumber(L,-1 - i));
-			break;
-		default:
-			LogPrint("vm","default =%s\n",lua_typename(L,-1 - i));
-			break;
-		}
-	   LogPrint("vm"," ");
-	}
-	LogPrint("vm","\n");
+    int i;
+    int top = lua_gettop(L);
+//  int top = 20;//debug
+    for(i = 0;i < top;i++){
+        int t = lua_type(L,-1 - i);
+        switch(t){
+        case LUA_TSTRING:
+            LogPrint("vm","%d str =%s\n", i, lua_tostring(L,-1 - i));
+            break;
+        case LUA_TBOOLEAN:
+            LogPrint("vm","boolean =%d\n",lua_toboolean(L,-1 - i));
+            break;
+        case LUA_TNUMBER:
+            LogPrint("vm","number =%d\n",lua_tonumber(L,-1 - i));
+            break;
+        default:
+            LogPrint("vm","default =%s\n",lua_typename(L,-1 - i));
+            break;
+        }
+       LogPrint("vm"," ");
+    }
+    LogPrint("vm","\n");
 }
 #endif
 /*
  *  //3.往函数私有栈里存运算后的结果*/
 static inline int RetRstToLua(lua_State *L,const vector<unsigned char> &ResultData )
 {
-	int len = ResultData.size();
-	len = len > LUA_C_BUFFER_SIZE ? LUA_C_BUFFER_SIZE : len;
+    int len = ResultData.size();
+    len = len > LUA_C_BUFFER_SIZE ? LUA_C_BUFFER_SIZE : len;
 
-    if(len > 0) {	//检测栈空间是否够
-    	if(lua_checkstack(L,len)){
-//			LogPrint("vm", "RetRstToLua value:%s\n",HexStr(ResultData).c_str());
-			for(int i = 0;i < len;i++){
-				lua_pushinteger(L, (lua_Integer) ResultData[i]);
-			}
-			return len ;
-    	}else{
-    		LogPrint("vm","%s\r\n", "RetRstToLua stack overflow");
-    	}
+    if(len > 0) {   //检测栈空间是否够
+        if(lua_checkstack(L,len)){
+//          LogPrint("vm", "RetRstToLua value:%s\n",HexStr(ResultData).c_str());
+            for(int i = 0;i < len;i++){
+                lua_pushinteger(L, (lua_Integer) ResultData[i]);
+            }
+            return len ;
+        }else{
+            LogPrint("vm","%s\n", "RetRstToLua stack overflow");
+        }
     } else {
-    	LogPrint("vm","RetRstToLua err len = %d\r\n", len);
+        LogPrint("vm","RetRstToLua err len = %d\n", len);
     }
     return  0;
 }
@@ -88,35 +88,35 @@ static inline int RetRstToLua(lua_State *L,const vector<unsigned char> &ResultDa
  *  //3.往函数私有栈里存布尔类型返回值*/
 static inline int RetRstBooleanToLua(lua_State *L,bool flag)
 {
-	//检测栈空间是否够
+    //检测栈空间是否够
    if (lua_checkstack(L,sizeof(int))) {
 //      LogPrint("vm", "RetRstBooleanToLua value:%d\n",flag);
-		lua_pushboolean(L,(int)flag);
-		return 1 ;
+        lua_pushboolean(L,(int)flag);
+        return 1 ;
    } else {
-	    LogPrint("vm","%s\r\n", "RetRstBooleanToLua stack overflow");
-		return 0;
+        LogPrint("vm","%s\n", "RetRstBooleanToLua stack overflow");
+            return 0;
    }
 }
 
 static inline int RetFalse(const string reason)
 {
-	 LogPrint("vm","%s\r\n", reason.c_str());
-	 return 0;
+     LogPrint("vm","%s\n", reason.c_str());
+     return 0;
 }
 static CVmRunEvn* GetVmRunEvn(lua_State *L)
 {
-	CVmRunEvn* pVmRunEvn = NULL;
-	int res = lua_getglobal(L, "VmScriptRun");
-	//LogPrint("vm", "GetVmRunEvn lua_getglobal:%d\n", res);
+    CVmRunEvn* pVmRunEvn = NULL;
+    int res = lua_getglobal(L, "VmScriptRun");
+    //LogPrint("vm", "GetVmRunEvn lua_getglobal:%d\n", res);
 
     if(LUA_TLIGHTUSERDATA == res)
     {
-    	if(lua_islightuserdata(L,-1))
-    	{
-    		pVmRunEvn = (CVmRunEvn*)lua_topointer(L,-1);
-    		//LogPrint("vm", "GetVmRunEvn lua_topointer:%p\n", pVmRunEvn);
-    	}
+        if(lua_islightuserdata(L,-1))
+        {
+            pVmRunEvn = (CVmRunEvn*)lua_topointer(L,-1);
+            //LogPrint("vm", "GetVmRunEvn lua_topointer:%p\n", pVmRunEvn);
+        }
     }
     lua_pop(L, 1);
 
@@ -124,102 +124,102 @@ static CVmRunEvn* GetVmRunEvn(lua_State *L)
 }
 
 static bool GetKeyId(const CAccountViewCache &view, vector<unsigned char> &ret,
-		CKeyID &KeyId) {
-	if (ret.size() == 6) {
-		CRegID reg(ret);
-		KeyId = reg.getKeyID(view);
-	} else if (ret.size() == 34) {
-		string addr(ret.begin(), ret.end());
-		KeyId = CKeyID(addr);
-	}else{
-		return false;
-	}
-	if (KeyId.IsEmpty())
-		return false;
+        CKeyID &KeyId) {
+    if (ret.size() == 6) {
+        CRegID reg(ret);
+        KeyId = reg.getKeyID(view);
+    } else if (ret.size() == 34) {
+        string addr(ret.begin(), ret.end());
+        KeyId = CKeyID(addr);
+    }else{
+        return false;
+    }
+    if (KeyId.IsEmpty())
+        return false;
 
-	return true;
+    return true;
 }
 static bool GetArray(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
-	//从栈里取变长的数组
-	int totallen = lua_gettop(L);
-	if((totallen <= 0) || (totallen > LUA_C_BUFFER_SIZE))
-	{
-		LogPrint("vm","totallen error\r\n");
-		return false;
-	}
+    //从栈里取变长的数组
+    int totallen = lua_gettop(L);
+    if((totallen <= 0) || (totallen > LUA_C_BUFFER_SIZE))
+    {
+        LogPrint("vm","totallen error\n");
+        return false;
+    }
 
     vector<unsigned char> vBuf;
-	vBuf.clear();
-	for(int i = 0;i < totallen;i++)
-	{
-		if(!lua_isnumber(L, i + 1))//if(!lua_isnumber(L,-1 - i))
-		{
-			LogPrint("vm","%s\r\n","data is not number");
-			return false;
-		}
-		vBuf.insert(vBuf.end(),lua_tonumber(L,i+1));
-	}
-	ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-	//LogPrint("vm", "GetData:%s, len:%d\n", HexStr(vBuf).c_str(), vBuf.size());
-	return true;
+    vBuf.clear();
+    for(int i = 0;i < totallen;i++)
+    {
+        if(!lua_isnumber(L, i + 1))//if(!lua_isnumber(L,-1 - i))
+        {
+            LogPrint("vm","%s\n","data is not number");
+            return false;
+        }
+        vBuf.insert(vBuf.end(),lua_tonumber(L,i+1));
+    }
+    ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+    //LogPrint("vm", "GetData:%s, len:%d\n", HexStr(vBuf).c_str(), vBuf.size());
+    return true;
 }
 static bool GetDataInt(lua_State *L,int &intValue) {
-	//从栈里取int 高度
-	if(!lua_isinteger(L,-1 - 0))
-	{
-		LogPrint("vm","%s\r\n","data is not integer");
-		return false;
-	}else{
-		int value = (int)lua_tointeger(L,-1 - 0);
-//		LogPrint("vm", "GetDataInt:%d\n", value);
-		intValue = value;
-		return true;
-	}
+    //从栈里取int 高度
+    if(!lua_isinteger(L,-1 - 0))
+    {
+        LogPrint("vm","%s\n","data is not integer");
+        return false;
+    }else{
+        int value = (int)lua_tointeger(L,-1 - 0);
+//      LogPrint("vm", "GetDataInt:%d\n", value);
+        intValue = value;
+        return true;
+    }
 }
 static bool GetDataString(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
-	//从栈里取一串字符串
-	if(!lua_isstring(L,-1 - 0))
-	{
-		LogPrint("vm","%s\r\n","data is not string");
-		return false;
-	}
+    //从栈里取一串字符串
+    if(!lua_isstring(L,-1 - 0))
+    {
+        LogPrint("vm","%s\n","data is not string");
+        return false;
+    }
     vector<unsigned char> vBuf;
-	vBuf.clear();
+    vBuf.clear();
     const char *pStr = NULL;
-	pStr = lua_tostring(L,-1 - 0);
-	if(pStr && (strlen(pStr) <= LUA_C_BUFFER_SIZE)){
-		for(size_t i = 0;i < strlen(pStr);i++){
-			vBuf.insert(vBuf.end(),pStr[i]);
-		}
-		ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-		//LogPrint("vm", "GetDataString:%s\n", pStr);
-		return true;
-	}else{
-		LogPrint("vm","%s\r\n","lua_tostring get fail");
-		return false;
-	}
+    pStr = lua_tostring(L,-1 - 0);
+    if(pStr && (strlen(pStr) <= LUA_C_BUFFER_SIZE)){
+        for(size_t i = 0;i < strlen(pStr);i++){
+            vBuf.insert(vBuf.end(),pStr[i]);
+        }
+        ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        //LogPrint("vm", "GetDataString:%s\n", pStr);
+        return true;
+    }else{
+        LogPrint("vm","%s\n","lua_tostring get fail");
+        return false;
+    }
 }
 static bool getNumberInTable(lua_State *L,char * pKey, double &ret){
-	// 在table里，取指定pKey对应的一个number值
+    // 在table里，取指定pKey对应的一个number值
 
     //默认栈顶是table，将pKey入栈
     lua_pushstring(L,pKey);
     lua_gettable(L,-2);  //查找键值为key的元素，置于栈顶
     if(!lua_isnumber(L,-1))
     {
-    	LogPrint("vm","num get error! %s\n",lua_tostring(L,-1));
-    	lua_pop(L,1); //删掉产生的查找结果
-    	return false;
+        LogPrint("vm","num get error! %s\n",lua_tostring(L,-1));
+        lua_pop(L,1); //删掉产生的查找结果
+        return false;
     }else{
-    	ret = lua_tonumber(L,-1);
-//    	LogPrint("vm", "getNumberInTable:%d\n", ret);
-		lua_pop(L,1); //删掉产生的查找结果
-		return true;
+        ret = lua_tonumber(L,-1);
+//      LogPrint("vm", "getNumberInTable:%d\n", ret);
+        lua_pop(L,1); //删掉产生的查找结果
+        return true;
     }
 }
 
 static bool getStringInTable(lua_State *L,char * pKey, string &strValue){
-	// 在table里，取指定pKey对应的string值
+    // 在table里，取指定pKey对应的string值
 
     const char *pStr = NULL;
     //默认栈顶是table，将pKey入栈
@@ -227,99 +227,99 @@ static bool getStringInTable(lua_State *L,char * pKey, string &strValue){
     lua_gettable(L,-2);  //查找键值为key的元素，置于栈顶
     if(!lua_isstring(L,-1))
     {
-    	LogPrint("vm","string get error! %s\n",lua_tostring(L,-1));
+        LogPrint("vm","string get error! %s\n",lua_tostring(L,-1));
     }else{
-    	pStr = lua_tostring(L,-1);
-    	if(pStr && (strlen(pStr) <= LUA_C_BUFFER_SIZE)){
-			string res(pStr);
-			strValue = res;
-//    		LogPrint("vm", "getStringInTable:%s\n", pStr);
-			lua_pop(L,1); //删掉产生的查找结果
-			return true;
-    	}else{
-    		LogPrint("vm","%s\r\n","lua_tostring get fail");
-    	}
+        pStr = lua_tostring(L,-1);
+        if(pStr && (strlen(pStr) <= LUA_C_BUFFER_SIZE)){
+            string res(pStr);
+            strValue = res;
+//          LogPrint("vm", "getStringInTable:%s\n", pStr);
+            lua_pop(L,1); //删掉产生的查找结果
+            return true;
+        }else{
+            LogPrint("vm","%s\n","lua_tostring get fail");
+        }
     }
     lua_pop(L,1); //删掉产生的查找结果
     return false;
 }
 
 static bool getArrayInTable(lua_State *L,char * pKey,unsigned short usLen,vector<unsigned char> &vOut){
-	// 在table里，取指定pKey对应的数组
+    // 在table里，取指定pKey对应的数组
 
     if((usLen <= 0) || (usLen > LUA_C_BUFFER_SIZE)){
-    	LogPrint("vm","usLen error\r\n");
-		return false;
+        LogPrint("vm","usLen error\n");
+        return false;
     }
     unsigned char value = 0;
     vOut.clear();
-	//默认栈顶是table，将key入栈
+    //默认栈顶是table，将key入栈
     lua_pushstring(L,pKey);
     lua_gettable(L,1);
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","getTableInTable is not table\n");
-    	return false;
+        LogPrint("vm","getTableInTable is not table\n");
+        return false;
     }
-	for (int i = 0; i < usLen; ++i)
-	{
-		lua_pushnumber(L, i+1); //将索引入栈
-		lua_gettable(L, -2);
-		if(!lua_isnumber(L,-1))
-		{
-			LogPrint("vm","getTableInTable is not number\n");
-			return false;
-		}
-		value = 0;
-		value = lua_tonumber(L, -1);
-		vOut.insert(vOut.end(),value);
-		lua_pop(L, 1);
-	}
+    for (int i = 0; i < usLen; ++i)
+    {
+        lua_pushnumber(L, i+1); //将索引入栈
+        lua_gettable(L, -2);
+        if(!lua_isnumber(L,-1))
+        {
+            LogPrint("vm","getTableInTable is not number\n");
+            return false;
+        }
+        value = 0;
+        value = lua_tonumber(L, -1);
+        vOut.insert(vOut.end(),value);
+        lua_pop(L, 1);
+    }
     lua_pop(L,1); //删掉产生的查找结果
     return true;
 }
 static bool getStringLogPrint(lua_State *L,char * pKey,unsigned short usLen,vector<unsigned char> &vOut){
-	//从栈里取 table的值是一串字符串
-	//该函数专用于写日志函数GetDataTableLogPrint，
+    //从栈里取 table的值是一串字符串
+    //该函数专用于写日志函数GetDataTableLogPrint，
     if((usLen <= 0) || (usLen > LUA_C_BUFFER_SIZE)){
-    	LogPrint("vm","usLen error\r\n");
-		return false;
+        LogPrint("vm","usLen error\n");
+        return false;
     }
 
 
-	//默认栈顶是table，将key入栈
+    //默认栈顶是table，将key入栈
     lua_pushstring(L,pKey);
     lua_gettable(L,1);
 
     const char *pStr = NULL;
     vOut.clear();
-	lua_getfield(L,-2,pKey);
-	//stackDump(L);
-	if(!lua_isstring(L,-1)/*LUA_TSTRING != lua_type(L, -1)*/)
-	{
-		LogPrint("vm","getStringLogPrint is not string\n");
-		return false;
-	}
-	pStr = lua_tostring(L,-1 - 0);
-	if(pStr && (strlen(pStr) == usLen)){
-		for(size_t i = 0;i < usLen;i++){
-			vOut.insert(vOut.end(),pStr[i]);
-		}
-//		LogPrint("vm", "getfieldTableString:%s\n", pStr);
-		lua_pop(L,1); //删掉产生的查找结果
-		return true;
-	}else{
-		LogPrint("vm","%s\r\n","getStringLogPrint get fail");
-		lua_pop(L, 1); //删掉产生的查找结果
-		return false;
-	}
+    lua_getfield(L,-2,pKey);
+    //stackDump(L);
+    if(!lua_isstring(L,-1)/*LUA_TSTRING != lua_type(L, -1)*/)
+    {
+        LogPrint("vm","getStringLogPrint is not string\n");
+        return false;
+    }
+    pStr = lua_tostring(L,-1 - 0);
+    if(pStr && (strlen(pStr) == usLen)){
+        for(size_t i = 0;i < usLen;i++){
+            vOut.insert(vOut.end(),pStr[i]);
+        }
+//      LogPrint("vm", "getfieldTableString:%s\n", pStr);
+        lua_pop(L,1); //删掉产生的查找结果
+        return true;
+    }else{
+        LogPrint("vm","%s\n","getStringLogPrint get fail\n");
+        lua_pop(L, 1); //删掉产生的查找结果
+        return false;
+    }
 }
 static bool GetDataTableLogPrint(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
-	//取日志的key value
+    //取日志的key value
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","GetDataTableLogPrint is not table\n");
-    	return false;
+        LogPrint("vm","GetDataTableLogPrint is not table\n");
+        return false;
     }
     unsigned short len = 0;
     vector<unsigned char> vBuf ;
@@ -327,113 +327,113 @@ static bool GetDataTableLogPrint(lua_State *L, vector<std::shared_ptr < std::vec
     int key = 0;
     double doubleValue = 0;
     if(!(getNumberInTable(L,(char *)"key",doubleValue))){
-    	LogPrint("vm", "key get fail\n");
-    	return false;
+        LogPrint("vm", "key get fail\n");
+        return false;
     }else{
-    	key = (int)doubleValue;
+        key = (int)doubleValue;
     }
-	vBuf.clear();
-	vBuf.insert(vBuf.end(),key);
+    vBuf.clear();
+    vBuf.insert(vBuf.end(),key);
     ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
 
     //取value的长度
     if(!(getNumberInTable(L,(char *)"length",doubleValue))){
-    	LogPrint("vm", "length get fail\n");
-    	return false;
+        LogPrint("vm", "length get fail\n");
+        return false;
     }else{
-    	len = (unsigned short)doubleValue;
+        len = (unsigned short)doubleValue;
     }
 
     if(len > 0)
     {
-    	len = len > LUA_C_BUFFER_SIZE ? LUA_C_BUFFER_SIZE : len;
-		if(key)
-		{   //hex
-			if(!getArrayInTable(L,(char *)"value",len,vBuf))
-			{
-				LogPrint("vm","valueTable is not table\n");
-				return false;
-			}else{
-				ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-			}
-		}else{ //string
-			if(!getStringLogPrint(L,(char *)"value",len,vBuf))
-			{
-				LogPrint("vm","valueString is not string\n");
-				return false;
-			}else{
-				ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-			}
-		}
-		return true;
+        len = len > LUA_C_BUFFER_SIZE ? LUA_C_BUFFER_SIZE : len;
+        if(key)
+        {   //hex
+            if(!getArrayInTable(L,(char *)"value",len,vBuf))
+            {
+                LogPrint("vm","valueTable is not table\n");
+                return false;
+            }else{
+                ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+            }
+        }else{ //string
+            if(!getStringLogPrint(L,(char *)"value",len,vBuf))
+            {
+                LogPrint("vm","valueString is not string\n");
+                return false;
+            }else{
+                ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+            }
+        }
+        return true;
     }else{
-    	LogPrint("vm", "length error\n");
-    	return false;
+        LogPrint("vm", "length error\n");
+        return false;
     }
 }
 static bool GetDataTableDes(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret)
 {
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","is not table\n");
-    	return false;
+        LogPrint("vm","is not table\n");
+        return false;
     }
     double doubleValue = 0;
     vector<unsigned char> vBuf ;
 
     int dataLen = 0;
     if(!(getNumberInTable(L,(char *)"dataLen",doubleValue))){
-    		LogPrint("vm","dataLen get fail\n");
-    		return false;
-    	}else{
-    		dataLen = (unsigned int)doubleValue;
+            LogPrint("vm","dataLen get fail\n");
+            return false;
+        }else{
+            dataLen = (unsigned int)doubleValue;
     }
 
     if(dataLen <= 0) {
-		LogPrint("vm","dataLen <= 0\n");
-		return false;
+        LogPrint("vm","dataLen <= 0\n");
+        return false;
     }
 
     if(!getArrayInTable(L,(char *)"data",dataLen,vBuf))
     {
-    	LogPrint("vm","data not table\n");
-    	return false;
+        LogPrint("vm","data not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
     int keyLen = 0;
     if(!(getNumberInTable(L,(char *)"keyLen",doubleValue))){
-    		LogPrint("vm","keyLen get fail\n");
-    		return false;
-    	}else{
-    		keyLen = (unsigned int)doubleValue;
+            LogPrint("vm","keyLen get fail\n");
+            return false;
+        }else{
+            keyLen = (unsigned int)doubleValue;
     }
 
     if(keyLen <= 0) {
-		LogPrint("vm","keyLen <= 0\n");
-		return false;
+        LogPrint("vm","keyLen <= 0\n");
+        return false;
     }
 
     if(!getArrayInTable(L,(char *)"key",keyLen,vBuf))
     {
-    	LogPrint("vm","key not table\n");
-    	return false;
+        LogPrint("vm","key not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
     int nFlag = 0;
     if(!(getNumberInTable(L,(char *)"flag",doubleValue))){
-    		LogPrint("vm","flag get fail\n");
-    		return false;
-    	}else{
-    		nFlag = (unsigned int)doubleValue;
-    		CDataStream tep(SER_DISK, CLIENT_VERSION);
-    		tep << (nFlag == 0 ? 0 : 1);
-    		ret.push_back(std::make_shared<vector<unsigned char>>(tep.begin(), tep.end()));
+            LogPrint("vm","flag get fail\n");
+            return false;
+        }else{
+            nFlag = (unsigned int)doubleValue;
+            CDataStream tep(SER_DISK, CLIENT_VERSION);
+            tep << (nFlag == 0 ? 0 : 1);
+            ret.push_back(std::make_shared<vector<unsigned char>>(tep.begin(), tep.end()));
     }
 
     return true;
@@ -443,179 +443,179 @@ static bool GetDataTableVerifySignature(lua_State *L, vector<std::shared_ptr < s
 {
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","is not table\n");
-    	return false;
+        LogPrint("vm","is not table\n");
+        return false;
     }
     double doubleValue = 0;
     vector<unsigned char> vBuf ;
 
     int dataLen = 0;
     if(!(getNumberInTable(L,(char *)"dataLen",doubleValue))){
-    		LogPrint("vm","dataLen get fail\n");
-    		return false;
-    	}else{
-    		dataLen = (unsigned int)doubleValue;
+            LogPrint("vm","dataLen get fail\n");
+            return false;
+        }else{
+            dataLen = (unsigned int)doubleValue;
     }
 
     if(dataLen <= 0) {
-		LogPrint("vm","dataLen <= 0\n");
-		return false;
+        LogPrint("vm","dataLen <= 0\n");
+        return false;
     }
 
     if(!getArrayInTable(L,(char *)"data",dataLen,vBuf))
     {
-    	LogPrint("vm","data not table\n");
-    	return false;
+        LogPrint("vm","data not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
     int keyLen = 0;
     if(!(getNumberInTable(L,(char *)"keyLen",doubleValue))){
-    		LogPrint("vm","keyLen get fail\n");
-    		return false;
-    	}else{
-    		keyLen = (unsigned int)doubleValue;
+            LogPrint("vm","keyLen get fail\n");
+            return false;
+        }else{
+            keyLen = (unsigned int)doubleValue;
     }
 
     if(keyLen <= 0) {
-		LogPrint("vm","keyLen <= 0\n");
-		return false;
+        LogPrint("vm","keyLen <= 0\n");
+        return false;
     }
 
     if(!getArrayInTable(L,(char *)"key",keyLen,vBuf))
     {
-    	LogPrint("vm","key not table\n");
-    	return false;
+        LogPrint("vm","key not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
     int hashLen = 0;
     if(!(getNumberInTable(L,(char *)"hashLen",doubleValue))){
-    		LogPrint("vm","hashLen get fail\n");
-    		return false;
-    	}else{
-    		hashLen = (unsigned int)doubleValue;
+            LogPrint("vm","hashLen get fail\n");
+            return false;
+        }else{
+            hashLen = (unsigned int)doubleValue;
     }
 
     if(hashLen <= 0) {
-		LogPrint("vm","hashLen <= 0\n");
-		return false;
+        LogPrint("vm","hashLen <= 0\n");
+        return false;
     }
 
     if(!getArrayInTable(L,(char *)"hash",hashLen,vBuf))
     {
-    	LogPrint("vm","hash not table\n");
-    	return false;
+        LogPrint("vm","hash not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
     return true;
 }
 
 static int ExInt64MulFunc(lua_State *L) {
-	int argc = lua_gettop(L);    /* number of arguments */
-	if(argc != 2) {
-    	return RetFalse("argc error\n");
-	}
+    int argc = lua_gettop(L);    /* number of arguments */
+    if(argc != 2) {
+        return RetFalse("argc error\n");
+    }
 
-	if(!lua_isinteger(L,1)) {
-    	return RetFalse("Int64Mul para1 error\n");
-	}
-	int64_t a = lua_tointeger(L,1);
+    if(!lua_isinteger(L,1)) {
+        return RetFalse("Int64Mul para1 error\n");
+    }
+    int64_t a = lua_tointeger(L,1);
 
-	if(!lua_isinteger(L,2)) {
-    	return RetFalse("Int64Mul para2 error\n");
-	}
-	int64_t b = lua_tointeger(L,2);
+    if(!lua_isinteger(L,2)) {
+        return RetFalse("Int64Mul para2 error\n");
+    }
+    int64_t b = lua_tointeger(L,2);
 
-	int64_t c = 0;
-	if(!SafeMultiply(a, b, c)) {
-		return RetFalse("Int64Mul Operate overflow !\n");
-	}
+    int64_t c = 0;
+    if(!SafeMultiply(a, b, c)) {
+        return RetFalse("Int64Mul Operate overflow !\n");
+    }
 
-	lua_pushinteger(L, c);
-	return 1;
+    lua_pushinteger(L, c);
+    return 1;
 }
 
 static int ExInt64AddFunc(lua_State *L) {
-	int argc = lua_gettop(L);    /* number of arguments */
-	if(argc != 2) {
-    	return RetFalse("argc error\n");
-	}
+    int argc = lua_gettop(L);    /* number of arguments */
+    if(argc != 2) {
+        return RetFalse("argc error\n");
+    }
 
-	if(!lua_isinteger(L,1)) {
-    	return RetFalse("Int64Add para1 error\n");
-	}
-	int64_t a = lua_tointeger(L,1);
+    if(!lua_isinteger(L,1)) {
+        return RetFalse("Int64Add para1 error\n");
+    }
+    int64_t a = lua_tointeger(L,1);
 
-	if(!lua_isinteger(L,2)) {
-    	return RetFalse("Int64Add para2 error\n");
-	}
-	int64_t b = lua_tointeger(L,2);
+    if(!lua_isinteger(L,2)) {
+        return RetFalse("Int64Add para2 error\n");
+    }
+    int64_t b = lua_tointeger(L,2);
 
-	int64_t c = 0;
-	if(!SafeAdd(a, b, c)) {
-		return RetFalse("Int64Add Operate overflow !\n");
-	}
+    int64_t c = 0;
+    if(!SafeAdd(a, b, c)) {
+        return RetFalse("Int64Add Operate overflow !\n");
+    }
 
-	lua_pushinteger(L, c);
-	return 1;
+    lua_pushinteger(L, c);
+    return 1;
 }
 
 static int ExInt64SubFunc(lua_State *L) {
-	int argc = lua_gettop(L);    /* number of arguments */
-	if(argc != 2) {
-    	return RetFalse("argc error\n");
-	}
+    int argc = lua_gettop(L);    /* number of arguments */
+    if(argc != 2) {
+        return RetFalse("argc error\n");
+    }
 
-	if(!lua_isinteger(L,1)) {
-    	return RetFalse("Int64Sub para1 error\n");
-	}
-	int64_t a = lua_tointeger(L,1);
+    if(!lua_isinteger(L,1)) {
+        return RetFalse("Int64Sub para1 error\n");
+    }
+    int64_t a = lua_tointeger(L,1);
 
-	if(!lua_isinteger(L,2)) {
-    	return RetFalse("Int64Sub para2 error\n");
-	}
-	int64_t b = lua_tointeger(L,2);
+    if(!lua_isinteger(L,2)) {
+        return RetFalse("Int64Sub para2 error\n");
+    }
+    int64_t b = lua_tointeger(L,2);
 
-	int64_t c = 0;
-	if(!SafeSubtract(a, b, c)) {
-		return RetFalse("Int64Sub Operate overflow !\n");
-	}
+    int64_t c = 0;
+    if(!SafeSubtract(a, b, c)) {
+        return RetFalse("Int64Sub Operate overflow !\n");
+    }
 
-	lua_pushinteger(L, c);
-	return 1;
+    lua_pushinteger(L, c);
+    return 1;
 }
 
 static int ExInt64DivFunc(lua_State *L) {
-	int argc = lua_gettop(L);    /* number of arguments */
-	if(argc != 2) {
-    	return RetFalse("argc error\n");
-	}
+    int argc = lua_gettop(L);    /* number of arguments */
+    if(argc != 2) {
+        return RetFalse("argc error\n");
+    }
 
-	if(!lua_isinteger(L,1)) {
-    	return RetFalse("Int64Div para1 error\n");
-	}
-	int64_t a = lua_tointeger(L,1);
+    if(!lua_isinteger(L,1)) {
+        return RetFalse("Int64Div para1 error\n");
+    }
+    int64_t a = lua_tointeger(L,1);
 
-	if(!lua_isinteger(L,2)) {
-    	return RetFalse("Int64Div para2 error\n");
-	}
-	int64_t b = lua_tointeger(L,2);
+    if(!lua_isinteger(L,2)) {
+        return RetFalse("Int64Div para2 error\n");
+    }
+    int64_t b = lua_tointeger(L,2);
 
-	int64_t c = 0;
-	if(!SafeDivide(a, b, c)) {
-		return RetFalse("Int64Div Operate overflow !\n");
-	}
+    int64_t c = 0;
+    if(!SafeDivide(a, b, c)) {
+        return RetFalse("Int64Div Operate overflow !\n");
+    }
 
-	lua_pushinteger(L, c);
-	return 1;
+    lua_pushinteger(L, c);
+    return 1;
 }
 
 /**
@@ -624,19 +624,19 @@ static int ExInt64DivFunc(lua_State *L) {
  * 1.第一个是要被计算hash值的字符串
  */
 static int ExSha256Func(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
-	if(!GetDataString(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() <= 0)
-	{
-		return RetFalse("ExSha256Func para err0");
-	}
+    if(!GetDataString(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() <= 0)
+    {
+        return RetFalse("ExSha256Func para err0");
+    }
 
-	uint256 rslt = Hash(&retdata.at(0).get()->at(0), &retdata.at(0).get()->at(0) + retdata.at(0).get()->size());
+    uint256 rslt = Hash(&retdata.at(0).get()->at(0), &retdata.at(0).get()->at(0) + retdata.at(0).get()->size());
 
-	CDataStream tep(SER_DISK, CLIENT_VERSION);
-	tep << rslt;
-	vector<unsigned char> tep1(tep.begin(), tep.end());
-	return RetRstToLua(L,tep1);
+    CDataStream tep(SER_DISK, CLIENT_VERSION);
+    tep << rslt;
+    vector<unsigned char> tep1(tep.begin(), tep.end());
+    return RetRstToLua(L,tep1);
 }
 
 /**
@@ -647,164 +647,164 @@ static int ExSha256Func(lua_State *L) {
  * 3.第三是标识符，是加密还是解密
  *
  * {
- * 	dataLen = 0,
- * 	data = {},
- * 	keyLen = 0,
- * 	key = {},
- * 	flag = 0
+ *  dataLen = 0,
+ *  data = {},
+ *  keyLen = 0,
+ *  key = {},
+ *  flag = 0
  * }
  */
 static int ExDesFunc(lua_State *L) {
-	vector<std::shared_ptr<vector<unsigned char> > > retdata;
+    vector<std::shared_ptr<vector<unsigned char> > > retdata;
 
-	if (!GetDataTableDes(L, retdata) || retdata.size() != 3) {
-		return RetFalse(string(__FUNCTION__) + "para  err !");
-	}
+    if (!GetDataTableDes(L, retdata) || retdata.size() != 3) {
+        return RetFalse(string(__FUNCTION__) + "para  err !");
+    }
 
-	DES_key_schedule deskey1, deskey2, deskey3;
+    DES_key_schedule deskey1, deskey2, deskey3;
 
-	vector<unsigned char> desdata;
-	vector<unsigned char> desout;
-	unsigned char datalen_rest = retdata.at(0).get()->size() % sizeof(DES_cblock);
-	desdata.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
-	if (datalen_rest) {
-		desdata.insert(desdata.end(), sizeof(DES_cblock) - datalen_rest, 0);
-	}
+    vector<unsigned char> desdata;
+    vector<unsigned char> desout;
+    unsigned char datalen_rest = retdata.at(0).get()->size() % sizeof(DES_cblock);
+    desdata.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
+    if (datalen_rest) {
+        desdata.insert(desdata.end(), sizeof(DES_cblock) - datalen_rest, 0);
+    }
 
-	const_DES_cblock in;
-	DES_cblock out, key;
+    const_DES_cblock in;
+    DES_cblock out, key;
 
-	desout.resize(desdata.size());
+    desout.resize(desdata.size());
 
-	unsigned char flag = retdata.at(2).get()->at(0);
-	if (flag == 1) {
-		if (retdata.at(1).get()->size() == 8) {
-			//			printf("the des encrypt\r\n");
-			memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey1);
-			for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
-				memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
-				//				printf("in :%s\r\n", HexStr(in, in + 8, true).c_str());
-				DES_ecb_encrypt(&in, &out, &deskey1, DES_ENCRYPT);
-				//				printf("out :%s\r\n", HexStr(out, out + 8, true).c_str());
-				memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
-			}
-		} else if (retdata.at(1).get()->size() == 16) {
-			//			printf("the 3 des encrypt\r\n");
-			memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey1);
-			DES_set_key_unchecked(&key, &deskey3);
-			memcpy(key, &retdata.at(1).get()->at(0) + sizeof(DES_cblock), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey2);
-			for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
-				memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
-				DES_ecb3_encrypt(&in, &out, &deskey1, &deskey2, &deskey3, DES_ENCRYPT);
-				memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
-			}
+    unsigned char flag = retdata.at(2).get()->at(0);
+    if (flag == 1) {
+        if (retdata.at(1).get()->size() == 8) {
+            //          printf("the des encrypt\n");
+            memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey1);
+            for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
+                memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
+                //              printf("in :%s\n", HexStr(in, in + 8, true).c_str());
+                DES_ecb_encrypt(&in, &out, &deskey1, DES_ENCRYPT);
+                //              printf("out :%s\n", HexStr(out, out + 8, true).c_str());
+                memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
+            }
+        } else if (retdata.at(1).get()->size() == 16) {
+            //          printf("the 3 des encrypt\n");
+            memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey1);
+            DES_set_key_unchecked(&key, &deskey3);
+            memcpy(key, &retdata.at(1).get()->at(0) + sizeof(DES_cblock), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey2);
+            for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
+                memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
+                DES_ecb3_encrypt(&in, &out, &deskey1, &deskey2, &deskey3, DES_ENCRYPT);
+                memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
+            }
 
-		} else {
-			//error
-			return RetFalse(string(__FUNCTION__) + "para  err !");
-		}
-	} else {
-		if (retdata.at(1).get()->size() == 8) {
-			//			printf("the des decrypt\r\n");
-			memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey1);
-			for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
-				memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
-				//				printf("in :%s\r\n", HexStr(in, in + 8, true).c_str());
-				DES_ecb_encrypt(&in, &out, &deskey1, DES_DECRYPT);
-				//				printf("out :%s\r\n", HexStr(out, out + 8, true).c_str());
-				memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
-			}
-		} else if (retdata.at(1).get()->size() == 16) {
-			//			printf("the 3 des decrypt\r\n");
-			memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey1);
-			DES_set_key_unchecked(&key, &deskey3);
-			memcpy(key, &retdata.at(1).get()->at(0) + sizeof(DES_cblock), sizeof(DES_cblock));
-			DES_set_key_unchecked(&key, &deskey2);
-			for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
-				memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
-				DES_ecb3_encrypt(&in, &out, &deskey1, &deskey2, &deskey3, DES_DECRYPT);
-				memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
-			}
-		} else {
-			//error
-			return RetFalse(string(__FUNCTION__) + "para  err !");
-		}
-	}
+        } else {
+            //error
+            return RetFalse(string(__FUNCTION__) + "para  err !");
+        }
+    } else {
+        if (retdata.at(1).get()->size() == 8) {
+            //          printf("the des decrypt\n");
+            memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey1);
+            for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
+                memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
+                //              printf("in :%s\n", HexStr(in, in + 8, true).c_str());
+                DES_ecb_encrypt(&in, &out, &deskey1, DES_DECRYPT);
+                //              printf("out :%s\n", HexStr(out, out + 8, true).c_str());
+                memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
+            }
+        } else if (retdata.at(1).get()->size() == 16) {
+            //          printf("the 3 des decrypt\n");
+            memcpy(key, &retdata.at(1).get()->at(0), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey1);
+            DES_set_key_unchecked(&key, &deskey3);
+            memcpy(key, &retdata.at(1).get()->at(0) + sizeof(DES_cblock), sizeof(DES_cblock));
+            DES_set_key_unchecked(&key, &deskey2);
+            for (unsigned int ii = 0; ii < desdata.size() / sizeof(DES_cblock); ii++) {
+                memcpy(&in, &desdata[ii * sizeof(DES_cblock)], sizeof(in));
+                DES_ecb3_encrypt(&in, &out, &deskey1, &deskey2, &deskey3, DES_DECRYPT);
+                memcpy(&desout[ii * sizeof(DES_cblock)], &out, sizeof(out));
+            }
+        } else {
+            //error
+            return RetFalse(string(__FUNCTION__) + "para  err !");
+        }
+    }
 
-	return RetRstToLua(L,desout);
+    return RetRstToLua(L,desout);
 }
 
 /**
  *bool SignatureVerify(void const* data, unsigned short datalen, void const* key, unsigned short keylen,
-		void const* phash, unsigned short hashlen)
+        void const* phash, unsigned short hashlen)
  * 这个函数式从中间层传了三个个参数过来:
  * 1.第一个是签名的数据
  * 2.第二个是用的签名的publickey
  * 3.第三是签名之前的hash值
  *
  *{
- * 	dataLen = 0,
- * 	data = {},
- * 	keyLen = 0,
- * 	key = {},
- * 	hashLen = 0,
- * 	hash = {}
+ *  dataLen = 0,
+ *  data = {},
+ *  keyLen = 0,
+ *  key = {},
+ *  hashLen = 0,
+ *  hash = {}
  * }
  */
 static int ExVerifySignatureFunc(lua_State *L) {
-	vector<std::shared_ptr<vector<unsigned char> > > retdata;
+    vector<std::shared_ptr<vector<unsigned char> > > retdata;
 
-	if (!GetDataTableVerifySignature(L, retdata) || retdata.size() != 3 || retdata.at(1).get()->size() != 33
-			|| retdata.at(2).get()->size() != 32) {
-		return RetFalse(string(__FUNCTION__) + "para  err !");
-	}
+    if (!GetDataTableVerifySignature(L, retdata) || retdata.size() != 3 || retdata.at(1).get()->size() != 33
+            || retdata.at(2).get()->size() != 32) {
+        return RetFalse(string(__FUNCTION__) + "para  err !");
+    }
 
-	CPubKey pk(retdata.at(1).get()->begin(), retdata.at(1).get()->end());
-	vector<unsigned char> vec_hash(retdata.at(2).get()->rbegin(), retdata.at(2).get()->rend());
-	uint256 hash(vec_hash);
-	auto tem = std::make_shared<std::vector<vector<unsigned char> > >();
+    CPubKey pk(retdata.at(1).get()->begin(), retdata.at(1).get()->end());
+    vector<unsigned char> vec_hash(retdata.at(2).get()->rbegin(), retdata.at(2).get()->rend());
+    uint256 hash(vec_hash);
+    auto tem = std::make_shared<std::vector<vector<unsigned char> > >();
 
-	bool rlt = CheckSignScript(hash, *retdata.at(0), pk);
-	if (!rlt) {
-		LogPrint("INFO", "ExVerifySignatureFunc call CheckSignScript verify signature failed!\n");
-	}
+    bool rlt = CheckSignScript(hash, *retdata.at(0), pk);
+    if (!rlt) {
+        LogPrint("INFO", "ExVerifySignatureFunc call CheckSignScript verify signature failed!\n");
+    }
 
-	return RetRstBooleanToLua(L, rlt);
+    return RetRstBooleanToLua(L, rlt);
 }
 
 
 static int ExGetTxContractsFunc(lua_State *L) {
 
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
     if(!GetArray(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() != 32)
     {
-    	return RetFalse(string(__FUNCTION__)+"para  err !");
+        return RetFalse(string(__FUNCTION__)+"para  err !");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
     vector<unsigned char> vec_hash(retdata.at(0).get()->rbegin(), retdata.at(0).get()->rend());
-	CDataStream tep1(vec_hash, SER_DISK, CLIENT_VERSION);
-	uint256 hash1;
-	tep1 >>hash1;
+    CDataStream tep1(vec_hash, SER_DISK, CLIENT_VERSION);
+    uint256 hash1;
+    tep1 >>hash1;
 
-	std::shared_ptr<CBaseTransaction> pBaseTx;
+    std::shared_ptr<CBaseTransaction> pBaseTx;
 
-	if (GetTransaction(pBaseTx, hash1, *pVmRunEvn->GetScriptDB(), false)) {
-		CTransaction *tx = static_cast<CTransaction*>(pBaseTx.get());
-		 return RetRstToLua(L, tx->vContract);
-	}
+    if (GetTransaction(pBaseTx, hash1, *pVmRunEvn->GetScriptDB(), false)) {
+        CTransaction *tx = static_cast<CTransaction*>(pBaseTx.get());
+         return RetRstToLua(L, tx->vContract);
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -814,23 +814,20 @@ static int ExGetTxContractsFunc(lua_State *L) {
  * 2.第二个是打印的字符串
  */
 static int ExLogPrintFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
-    if(!GetDataTableLogPrint(L,retdata) ||retdata.size() != 2)
-    {
-    	return RetFalse("ExLogPrintFunc para err1");
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    if(!GetDataTableLogPrint(L,retdata) || retdata.size() != 2) {
+        return RetFalse("ExLogPrintFunc para err1");
     }
-	CDataStream tep1(*retdata.at(0), SER_DISK, CLIENT_VERSION);
-	bool flag ;
-	tep1 >> flag;
-	string pdata((*retdata[1]).begin(), (*retdata[1]).end());
+    CDataStream tep1(*retdata.at(0), SER_DISK, CLIENT_VERSION);
+    bool flag ;
+    tep1 >> flag;
+    string pdata((*retdata[1]).begin(), (*retdata[1]).end());
 
-	if(flag)
-	{
-		LogPrint("vm","%s\r\n", HexStr(pdata).c_str());
-	}else
-	{
-		LogPrint("vm","%s\r\n",pdata.c_str());
-	}
+    if(flag) {
+        LogPrint("vm","%s\n", HexStr(pdata).c_str());
+    } else {
+        LogPrint("vm","%s\n", pdata.c_str());
+    }
     return  0;
 }
 
@@ -840,42 +837,46 @@ static int ExLogPrintFunc(lua_State *L) {
  * 这个函数式从中间层传了一个参数过来:
  * 1.第一个是 hash
  */
-static int ExGetTxAccountsFunc(lua_State *L) {
-	vector<std::shared_ptr<vector<unsigned char> > > retdata;
-    if (!GetArray(L,retdata) ||retdata.size() != 1|| retdata.at(0).get()->size() != 32) {
-    	return RetFalse("ExGetTxAccountsFunc para err1");
+static int ExGetTxRegIDFunc(lua_State *L) {
+    vector<std::shared_ptr<vector<unsigned char> > > retdata;
+    if (!GetArray(L, retdata) || retdata.size() != 1 || retdata.at(0).get()->size() != 32) {
+        return RetFalse("ExGetTxRegIDFunc, para error");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if (NULL == pVmRunEvn) {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("ExGetTxRegIDFunc, pVmRunEvn is NULL");
     }
 
-    vector<unsigned char> vec_hash(retdata.at(0).get()->rbegin(), retdata.at(0).get()->rend());
+    vector<unsigned char> vHash(retdata.at(0).get()->rbegin(), retdata.at(0).get()->rend());
 
-	CDataStream tep1(vec_hash, SER_DISK, CLIENT_VERSION);
-	uint256 hash1;
-	tep1 >>hash1;
+    CDataStream ds(vHash, SER_DISK, CLIENT_VERSION);
+    uint256 hash;
+    ds >> hash;
 
-	LogPrint("vm","ExGetTxAccountsFunc:%s",hash1.GetHex().c_str());
-	std::shared_ptr<CBaseTransaction> pBaseTx;
+    LogPrint("vm","ExGetTxRegIDFunc, hash: %s\n", hash.GetHex().c_str());
+    std::shared_ptr<CBaseTransaction> pBaseTx;
 
-//	auto tem = make_shared<std::vector<vector<unsigned char> > >();
     int len = 0;
-	if ( GetTransaction(pBaseTx, hash1, *pVmRunEvn->GetScriptDB(), false) ) {
-		CTransaction *tx = static_cast<CTransaction*>(pBaseTx.get());
-		vector<unsigned char> item = boost::get<CRegID>(tx->srcRegId).GetVec6();
-		len = RetRstToLua(L, item);
-	}
-	return len;
+    if (GetTransaction(pBaseTx, hash, *pVmRunEvn->GetScriptDB(), false)) {
+        if (pBaseTx->nTxType == COMMON_TX || pBaseTx->nTxType == CONTRACT_TX) {
+            CTransaction *tx = static_cast<CTransaction*>(pBaseTx.get());
+            vector<unsigned char> item = boost::get<CRegID>(tx->srcRegId).GetVec6();
+            len = RetRstToLua(L, item);
+        } else {
+            return RetFalse("ExGetTxRegIDFunc, tx type error");
+        }
+    }
+
+    return len;
 }
 
 static int ExByteToIntegerFunc(lua_State *L) {
-	//把字节流组合成integer
-	vector< std::shared_ptr<vector<unsigned char>> > retdata;
-    if( !GetArray(L, retdata) ||retdata.size() != 1 || 
-		((retdata.at(0).get()->size() != 4) && (retdata.at(0).get()->size() != 8)) ) {
-    	return RetFalse("ExByteToIntegerFunc para err1");
+    //把字节流组合成integer
+    vector< std::shared_ptr<vector<unsigned char>> > retdata;
+    if( !GetArray(L, retdata) ||retdata.size() != 1 ||
+        ((retdata.at(0).get()->size() != 4) && (retdata.at(0).get()->size() != 8)) ) {
+        return RetFalse("ExByteToIntegerFunc para err1");
     }
 
     //将数据反向
@@ -883,34 +884,34 @@ static int ExByteToIntegerFunc(lua_State *L) {
     CDataStream tep1(vValue, SER_DISK, CLIENT_VERSION);
 
     if(retdata.at(0).get()->size() == 4) {
-		unsigned int height;
-		tep1 >>height;
+        unsigned int height;
+        tep1 >>height;
 
-//		LogPrint("vm","%d\r\n", height);
-	   if(lua_checkstack(L,sizeof(lua_Integer))){
-			lua_pushinteger(L,(lua_Integer)height);
-			return 1 ;
-	   }else{
-			return RetFalse("ExByteToIntegerFunc stack overflow");
-	   }
+//      LogPrint("vm","%d\n", height);
+       if(lua_checkstack(L,sizeof(lua_Integer))){
+            lua_pushinteger(L,(lua_Integer)height);
+            return 1 ;
+       }else{
+            return RetFalse("ExByteToIntegerFunc stack overflow");
+       }
     } else {
-		int64_t llValue = 0;
-		tep1 >>llValue;
-//		LogPrint("vm","%lld\r\n", llValue);
-	   if (lua_checkstack(L, sizeof(lua_Integer))) {
-			lua_pushinteger(L, (lua_Integer)llValue);
-			return 1 ;
-	   } else {
-			return RetFalse("ExByteToIntegerFunc stack overflow");
-	   }
+        int64_t llValue = 0;
+        tep1 >>llValue;
+//      LogPrint("vm","%lld\n", llValue);
+       if (lua_checkstack(L, sizeof(lua_Integer))) {
+            lua_pushinteger(L, (lua_Integer)llValue);
+            return 1 ;
+       } else {
+            return RetFalse("ExByteToIntegerFunc stack overflow");
+       }
     }
 }
 
 static int ExIntegerToByte4Func(lua_State *L) {
-	//把integer转换成4字节数组
-	int height = 0;
+    //把integer转换成4字节数组
+    int height = 0;
     if(!GetDataInt(L,height)){
-    	return RetFalse("ExGetBlockHashFunc para err1");
+        return RetFalse("ExGetBlockHashFunc para err1");
     }
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << height;
@@ -918,16 +919,16 @@ static int ExIntegerToByte4Func(lua_State *L) {
     return RetRstToLua(L,TMP);
 }
 static int ExIntegerToByte8Func(lua_State *L) {
-	//把integer转换成8字节数组
-	int64_t llValue = 0;
-	if(!lua_isinteger(L,-1 - 0))
-	{
-		LogPrint("vm","%s\r\n","data is not integer");
-		return 0;
-	}else{
-		llValue = (int64_t)lua_tointeger(L,-1 - 0);
-//		LogPrint("vm", "ExIntegerToByte8Func:%lld\n", llValue);
-	}
+    //把integer转换成8字节数组
+    int64_t llValue = 0;
+    if(!lua_isinteger(L,-1 - 0))
+    {
+        LogPrint("vm","%s\n","data is not integer");
+        return 0;
+    }else{
+        llValue = (int64_t)lua_tointeger(L,-1 - 0);
+//      LogPrint("vm", "ExIntegerToByte8Func:%lld\n", llValue);
+    }
 
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << llValue;
@@ -940,38 +941,38 @@ static int ExIntegerToByte8Func(lua_State *L) {
  * 1.第一个是 账户id,六个字节
  */
 static int ExGetAccountPublickeyFunc(lua_State *L) {
-	vector<std::shared_ptr<vector<unsigned char> > > retdata;
+    vector<std::shared_ptr<vector<unsigned char> > > retdata;
     if(!GetArray(L,retdata) ||retdata.size() != 1
-    	|| !(retdata.at(0).get()->size() == 6 || retdata.at(0).get()->size() == 34))
+        || !(retdata.at(0).get()->size() == 6 || retdata.at(0).get()->size() == 34))
     {
-    	return RetFalse("ExGetAccountPublickeyFunc para err1");
+        return RetFalse("ExGetAccountPublickeyFunc para err1");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	 CKeyID addrKeyId;
-	 if (!GetKeyId(*(pVmRunEvn->GetCatchView()),*retdata.at(0).get(), addrKeyId)) {
-	    	return RetFalse("ExGetAccountPublickeyFunc para err2");
-	 }
-	CUserID userid(addrKeyId);
-	CAccount aAccount;
-	if (!pVmRunEvn->GetCatchView()->GetAccount(userid, aAccount)) {
-		return RetFalse("ExGetAccountPublickeyFunc para err3");
-	}
+     CKeyID addrKeyId;
+     if (!GetKeyId(*(pVmRunEvn->GetCatchView()),*retdata.at(0).get(), addrKeyId)) {
+            return RetFalse("ExGetAccountPublickeyFunc para err2");
+     }
+    CUserID userid(addrKeyId);
+    CAccount aAccount;
+    if (!pVmRunEvn->GetCatchView()->GetAccount(userid, aAccount)) {
+        return RetFalse("ExGetAccountPublickeyFunc para err3");
+    }
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     vector<char> te;
     tep << aAccount.PublicKey;
 //    assert(aAccount.PublicKey.IsFullyValid());
     if(false == aAccount.PublicKey.IsFullyValid()){
-    	return RetFalse("ExGetAccountPublickeyFunc PublicKey invalid");
+        return RetFalse("ExGetAccountPublickeyFunc PublicKey invalid");
     }
     tep >>te;
     vector<unsigned char> tep1(te.begin(),te.end());
-	return RetRstToLua(L,tep1);
+    return RetRstToLua(L,tep1);
 }
 
 /**
@@ -980,39 +981,39 @@ static int ExGetAccountPublickeyFunc(lua_State *L) {
  * 1.第一个是 账户id,六个字节
  */
 static int ExQueryAccountBalanceFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
     if(!GetArray(L,retdata) ||retdata.size() != 1
-    	|| !(retdata.at(0).get()->size() == 6 || retdata.at(0).get()->size() == 34))
+        || !(retdata.at(0).get()->size() == 6 || retdata.at(0).get()->size() == 34))
     {
-    	return RetFalse("ExQueryAccountBalanceFunc para err1");
+        return RetFalse("ExQueryAccountBalanceFunc para err1");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	 CKeyID addrKeyId;
-	 if (!GetKeyId(*(pVmRunEvn->GetCatchView()),*retdata.at(0).get(), addrKeyId)) {
-	    	return RetFalse("ExQueryAccountBalanceFunc para err2");
-	 }
+     CKeyID addrKeyId;
+     if (!GetKeyId(*(pVmRunEvn->GetCatchView()),*retdata.at(0).get(), addrKeyId)) {
+            return RetFalse("ExQueryAccountBalanceFunc para err2");
+     }
 
-	 CUserID userid(addrKeyId);
-	 CAccount aAccount;
-	 int len = 0;
-	if (!pVmRunEvn->GetCatchView()->GetAccount(userid, aAccount)) {
-		len = 0;
-	}
-	else
-	{
-		uint64_t nbalance = aAccount.GetRawBalance();
-		CDataStream tep(SER_DISK, CLIENT_VERSION);
-		tep << nbalance;
-		vector<unsigned char> TMP(tep.begin(),tep.end());
-		len = RetRstToLua(L,TMP);
-	}
-	return len;
+     CUserID userid(addrKeyId);
+     CAccount aAccount;
+     int len = 0;
+    if (!pVmRunEvn->GetCatchView()->GetAccount(userid, aAccount)) {
+        len = 0;
+    }
+    else
+    {
+        uint64_t nbalance = aAccount.GetRawBalance();
+        CDataStream tep(SER_DISK, CLIENT_VERSION);
+        tep << nbalance;
+        vector<unsigned char> TMP(tep.begin(),tep.end());
+        len = RetRstToLua(L,TMP);
+    }
+    return len;
 }
 
 /**
@@ -1021,42 +1022,42 @@ static int ExQueryAccountBalanceFunc(lua_State *L) {
  * 1.第一个入参: hash,32个字节
  */
 static int ExGetTxConfirmHeightFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetArray(L,retdata) ||retdata.size() != 1|| retdata.at(0).get()->size() != 32)
     {
-    	return RetFalse("ExGetTxConfirmHeightFunc para err1");
+        return RetFalse("ExGetTxConfirmHeightFunc para err1");
     }
 
-	// uint256 hash1(*retdata.at(0));
-	// LogPrint("vm","ExGetTxContractsFunc1:%s",hash1.GetHex().c_str());
+    // uint256 hash1(*retdata.at(0));
+    // LogPrint("vm","ExGetTxContractsFunc1:%s",hash1.GetHex().c_str());
 
-	// reverse hash value
- 	vector<unsigned char> vec_hash(retdata.at(0).get()->rbegin(), retdata.at(0).get()->rend());
-	CDataStream tep1(vec_hash, SER_DISK, CLIENT_VERSION);
-	uint256 hash1;
-	tep1 >>hash1;
+    // reverse hash value
+    vector<unsigned char> vec_hash(retdata.at(0).get()->rbegin(), retdata.at(0).get()->rend());
+    CDataStream tep1(vec_hash, SER_DISK, CLIENT_VERSION);
+    uint256 hash1;
+    tep1 >>hash1;
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	int nHeight = GetTxConfirmHeight(hash1, *pVmRunEvn->GetScriptDB());
-	if(-1 == nHeight)
-	{
-		return RetFalse("ExGetTxConfirmHeightFunc para err2");
-	}
-	else{
-	   if(lua_checkstack(L,sizeof(lua_Number))){
-			lua_pushnumber(L,(lua_Number)nHeight);
-			return 1 ;
-	   }else{
-		   LogPrint("vm","%s\r\n", "ExGetCurRunEnvHeightFunc stack overflow");
-		   return 0;
-	   }
-	}
+    int nHeight = GetTxConfirmHeight(hash1, *pVmRunEvn->GetScriptDB());
+    if(-1 == nHeight)
+    {
+        return RetFalse("ExGetTxConfirmHeightFunc para err2");
+    }
+    else{
+       if(lua_checkstack(L,sizeof(lua_Number))){
+            lua_pushnumber(L,(lua_Number)nHeight);
+            return 1 ;
+       }else{
+           LogPrint("vm","%s\n", "ExGetCurRunEnvHeightFunc stack overflow");
+           return 0;
+       }
+    }
 }
 
 
@@ -1066,34 +1067,34 @@ static int ExGetTxConfirmHeightFunc(lua_State *L) {
  * 1.第一个是 int类型的参数
  */
 static int ExGetBlockHashFunc(lua_State *L) {
-	int height = 0;
+    int height = 0;
     if(!GetDataInt(L,height)){
-    	return RetFalse("ExGetBlockHashFunc para err1");
+        return RetFalse("ExGetBlockHashFunc para err1");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	if (height <= 0 || height >= pVmRunEvn->GetComfirHeight()) //当前block 是不可以获取hash的
-	{
-		return RetFalse("ExGetBlockHashFunc para err2");
-	}
+    if (height <= 0 || height >= pVmRunEvn->GetComfirHeight()) //当前block 是不可以获取hash的
+    {
+        return RetFalse("ExGetBlockHashFunc para err2");
+    }
 
-	if(chainActive.Height() < height){	         //获取比当前高度高的数据是不可以的
-		return RetFalse("ExGetBlockHashFunc para err3");
-	}
-	CBlockIndex *pindex = chainActive[height];
-	uint256 blockHash = pindex->GetBlockHash();
+    if(chainActive.Height() < height){           //获取比当前高度高的数据是不可以的
+        return RetFalse("ExGetBlockHashFunc para err3");
+    }
+    CBlockIndex *pindex = chainActive[height];
+    uint256 blockHash = pindex->GetBlockHash();
 
-//	LogPrint("vm","ExGetBlockHashFunc:%s",HexStr(blockHash).c_str());
+//  LogPrint("vm","ExGetBlockHashFunc:%s",HexStr(blockHash).c_str());
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << blockHash;
     vector<unsigned char> TMP(tep.begin(),tep.end());
     // reverse hash value
-	vector<unsigned char> TMP2(TMP.rbegin(),TMP.rend());
+    vector<unsigned char> TMP2(TMP.rbegin(),TMP.rend());
     return RetRstToLua(L,TMP2);
 }
 
@@ -1101,82 +1102,82 @@ static int ExGetCurRunEnvHeightFunc(lua_State *L) {
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	int height = pVmRunEvn->GetComfirHeight();
+    int height = pVmRunEvn->GetComfirHeight();
 
-	//检测栈空间是否够
+    //检测栈空间是否够
    if(height > 0)
    {
-	   //lua_Integer
-	   /*
-	   if(lua_checkstack(L,sizeof(lua_Number))){
-			lua_pushnumber(L,(lua_Number)height);
-			return 1 ;
-	   }else{
-		   LogPrint("vm","%s\r\n", "ExGetCurRunEnvHeightFunc stack overflow");
-	   }
-	   */
-	   if(lua_checkstack(L,sizeof(lua_Integer))){
-		   lua_pushinteger(L,(lua_Integer)height);
-			return 1 ;
-	   }else{
-		   LogPrint("vm","%s\r\n", "ExGetCurRunEnvHeightFunc stack overflow");
-	   }
+       //lua_Integer
+       /*
+       if(lua_checkstack(L,sizeof(lua_Number))){
+            lua_pushnumber(L,(lua_Number)height);
+            return 1 ;
+       }else{
+           LogPrint("vm","%s\n", "ExGetCurRunEnvHeightFunc stack overflow");
+       }
+       */
+       if(lua_checkstack(L,sizeof(lua_Integer))){
+           lua_pushinteger(L,(lua_Integer)height);
+            return 1 ;
+       }else{
+           LogPrint("vm","%s\n", "ExGetCurRunEnvHeightFunc stack overflow");
+       }
    }else{
-	   LogPrint("vm","ExGetCurRunEnvHeightFunc err height =%d\r\n", height);
+       LogPrint("vm","ExGetCurRunEnvHeightFunc err height =%d\n", height);
    }
    return 0;
 }
 
 static bool GetDataTableWriteDataDB(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
-	//取写数据库的key value
+    //取写数据库的key value
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","GetDataTableWriteOutput is not table\n");
-    	return false;
+        LogPrint("vm","GetDataTableWriteOutput is not table\n");
+        return false;
     }
-	unsigned short len = 0;
+    unsigned short len = 0;
     vector<unsigned char> vBuf ;
     //取key
     string key = "";
     if(!(getStringInTable(L,(char *)"key",key))){
-    	LogPrint("vm","key get fail\n");
-    	return false;
+        LogPrint("vm","key get fail\n");
+        return false;
     }else{
-//		LogPrint("vm", "key:%s\n", key);
+//      LogPrint("vm", "key:%s\n", key);
     }
-	vBuf.clear();
-	for(size_t i = 0;i < key.size();i++)
-	{
-		vBuf.insert(vBuf.end(),key.at(i));
-	}
+    vBuf.clear();
+    for(size_t i = 0;i < key.size();i++)
+    {
+        vBuf.insert(vBuf.end(),key.at(i));
+    }
     ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
 
     //取value的长度
     double doubleValue = 0;
     if(!(getNumberInTable(L,(char *)"length",doubleValue))){
-    	LogPrint("vm", "length get fail\n");
-    	return false;
+        LogPrint("vm", "length get fail\n");
+        return false;
     }else{
-    	 len = (unsigned short)doubleValue;
-//    	 LogPrint("vm","len =%d\n",len);
+         len = (unsigned short)doubleValue;
+//       LogPrint("vm","len =%d\n",len);
     }
     if((len > 0) && (len <= LUA_C_BUFFER_SIZE))
     {
-		if(!getArrayInTable(L,(char *)"value",len,vBuf))
-		{
-			LogPrint("vm","value is not table\n");
-			return false;
-		}else{
-//			LogPrint("vm", "value:%s\n", HexStr(vBuf).c_str());
-			ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-		}
-		return true;
+        if(!getArrayInTable(L,(char *)"value",len,vBuf))
+        {
+            LogPrint("vm","value is not table\n");
+            return false;
+        }else{
+//          LogPrint("vm", "value:%s\n", HexStr(vBuf).c_str());
+            ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        }
+        return true;
     }else{
-    	LogPrint("vm","len overflow\n");
-		return false;
+        LogPrint("vm","len overflow\n");
+        return false;
     }
 }
 
@@ -1187,32 +1188,32 @@ static bool GetDataTableWriteDataDB(lua_State *L, vector<std::shared_ptr < std::
  * 2.第二个是value值
  */
 static int ExWriteDataDBFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetDataTableWriteDataDB(L,retdata) ||retdata.size() != 2)
     {
-    	return RetFalse("ExWriteDataDBFunc key err1");
+        return RetFalse("ExWriteDataDBFunc key err1");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	const CRegID scriptid = pVmRunEvn->GetScriptRegID();
-	bool flag = true;
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    const CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    bool flag = true;
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
 
-	CScriptDBOperLog operlog;
-//	int64_t step = (*retdata.at(1)).size() -1;
-	if (!scriptDB->SetAppData(scriptid, *retdata.at(0), *retdata.at(1),operlog)) {
-		flag = false;
-	} else {
-		shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
-		(*m_dblog.get()).push_back(operlog);
-	}
-	return RetRstBooleanToLua(L,flag);
+    CScriptDBOperLog operlog;
+//  int64_t step = (*retdata.at(1)).size() -1;
+    if (!scriptDB->SetAppData(scriptid, *retdata.at(0), *retdata.at(1),operlog)) {
+        flag = false;
+    } else {
+        shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
+        (*m_dblog.get()).push_back(operlog);
+    }
+    return RetRstBooleanToLua(L,flag);
 }
 
 /**
@@ -1221,36 +1222,36 @@ static int ExWriteDataDBFunc(lua_State *L) {
  * 1.第一个是 key值
  */
 static int ExDeleteDataDBFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
-	if(!GetDataString(L,retdata) ||retdata.size() != 1)
+    if(!GetDataString(L,retdata) ||retdata.size() != 1)
     {
-    	LogPrint("vm", "ExDeleteDataDBFunc key err1");
-    	return RetFalse(string(__FUNCTION__)+"para  err !");
+        LogPrint("vm", "ExDeleteDataDBFunc key err1");
+        return RetFalse(string(__FUNCTION__)+"para  err !");
     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
-	CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    CRegID scriptid = pVmRunEvn->GetScriptRegID();
 
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
 
-	bool flag = true;
-	CScriptDBOperLog operlog;
-	int64_t nstep = 0;
-	vector<unsigned char> vValue;
-	if(scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vValue)){
-		nstep = nstep - (int64_t)(vValue.size()+1);//删除数据奖励step
-	}
-	if (!scriptDB->EraseAppData(scriptid, *retdata.at(0), operlog)) {
-		LogPrint("vm", "ExDeleteDataDBFunc error key:%s!\n",HexStr(*retdata.at(0)));
-		flag = false;
-	} else {
-		shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
-		m_dblog.get()->push_back(operlog);
-	}
+    bool flag = true;
+    CScriptDBOperLog operlog;
+    int64_t nstep = 0;
+    vector<unsigned char> vValue;
+    if(scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vValue)){
+        nstep = nstep - (int64_t)(vValue.size()+1);//删除数据奖励step
+    }
+    if (!scriptDB->EraseAppData(scriptid, *retdata.at(0), operlog)) {
+        LogPrint("vm", "ExDeleteDataDBFunc error key:%s!\n",HexStr(*retdata.at(0)));
+        flag = false;
+    } else {
+        shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
+        m_dblog.get()->push_back(operlog);
+    }
     return RetRstBooleanToLua(L,flag);
 }
 
@@ -1260,55 +1261,55 @@ static int ExDeleteDataDBFunc(lua_State *L) {
  * 1.第一个是 key值
  */
 static int ExReadDataValueDBFunc(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetDataString(L,retdata) ||retdata.size() != 1)
     {
-    	return RetFalse("ExReadDataValueDBFunc key err1");
+        return RetFalse("ExReadDataValueDBFunc key err1");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    CRegID scriptid = pVmRunEvn->GetScriptRegID();
 
-	vector_unsigned_char vValue;
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
-	int len = 0;
-	if(!scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vValue))
-	{
-		len = 0;
-	}
-	else
-	{
-		len = RetRstToLua(L,vValue);
-	}
-	return len;
+    vector_unsigned_char vValue;
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    int len = 0;
+    if(!scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vValue))
+    {
+        len = 0;
+    }
+    else
+    {
+        len = RetRstToLua(L,vValue);
+    }
+    return len;
 }
 
 #if 0
 static int ExGetDBSizeFunc(lua_State *L) {
-//	CVmRunEvn *pVmRunEvn = (CVmRunEvn *)pVmEvn;
-	CRegID scriptid = pVmRunEvn->GetScriptRegID();
-	int count = 0;
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
-	if(!scriptDB->GetAppItemCount(scriptid,count))
-	{
-		return RetFalse("ExGetDBSizeFunc can't use");
-	}
-	else
-	{
-//		CDataStream tep(SER_DISK, CLIENT_VERSION);
-//		tep << count;
-//		vector<unsigned char> tep1(tep.begin(),tep.end());
+//  CVmRunEvn *pVmRunEvn = (CVmRunEvn *)pVmEvn;
+    CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    int count = 0;
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    if(!scriptDB->GetAppItemCount(scriptid,count))
+    {
+        return RetFalse("ExGetDBSizeFunc can't use");
+    }
+    else
+    {
+//      CDataStream tep(SER_DISK, CLIENT_VERSION);
+//      tep << count;
+//      vector<unsigned char> tep1(tep.begin(),tep.end());
 //        return RetRstToLua(L,tep1);
-		LogPrint("vm", "ExGetDBSizeFunc:%d\n", count);
-	    lua_pushnumber(L,(lua_Number)count);
-		return 1 ;
-	}
+        LogPrint("vm", "ExGetDBSizeFunc:%d\n", count);
+        lua_pushnumber(L,(lua_Number)count);
+        return 1 ;
+    }
 }
 
 /**
@@ -1321,38 +1322,38 @@ static int ExGetDBSizeFunc(lua_State *L) {
  */
 static int ExGetDBValueFunc(lua_State *L) {
 
-	if (SysCfg().GetArg("-isdbtraversal", 0) == 0) {
-    	return RetFalse("ExGetDBValueFunc can't use");
-	}
+    if (SysCfg().GetArg("-isdbtraversal", 0) == 0) {
+        return RetFalse("ExGetDBValueFunc can't use");
+    }
 
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
     if(!GetArray(L,retdata) ||(retdata.size() != 2 && retdata.size() != 1))
     {
-    	return RetFalse("ExGetDBValueFunc index err1");
+        return RetFalse("ExGetDBValueFunc index err1");
     }
-	int index = 0;
-	bool flag = true;
-	memcpy(&index,&retdata.at(0).get()->at(0),sizeof(int));
-	if(!(index == 0 ||(index == 1 && retdata.size() == 2)))
-	{
-	    return RetFalse("ExGetDBValueFunc para err2");
-	}
-	CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    int index = 0;
+    bool flag = true;
+    memcpy(&index,&retdata.at(0).get()->at(0),sizeof(int));
+    if(!(index == 0 ||(index == 1 && retdata.size() == 2)))
+    {
+        return RetFalse("ExGetDBValueFunc para err2");
+    }
+    CRegID scriptid = pVmRunEvn->GetScriptRegID();
 
-	vector_unsigned_char vValue;
-	vector<unsigned char> vScriptKey;
-	if(index == 1)
-	{
-		vScriptKey.assign(retdata.at(1).get()->begin(),retdata.at(1).get()->end());
-	}
+    vector_unsigned_char vValue;
+    vector<unsigned char> vScriptKey;
+    if(index == 1)
+    {
+        vScriptKey.assign(retdata.at(1).get()->begin(),retdata.at(1).get()->end());
+    }
 
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
-	flag = scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid,index,vScriptKey,vValue);
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    flag = scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid,index,vScriptKey,vValue);
     int len = 0;
-	if(flag){
-	    len = RetRstToLua(L,vScriptKey) + RetRstToLua(L,vValue);
-	}
-	return len;
+    if(flag){
+        len = RetRstToLua(L,vScriptKey) + RetRstToLua(L,vValue);
+    }
+    return len;
 }
 #endif
 
@@ -1360,9 +1361,9 @@ static int ExGetCurTxHash(lua_State *L) {
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
-	uint256 hash = pVmRunEvn->GetCurTxHash();
+    uint256 hash = pVmRunEvn->GetCurTxHash();
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << hash;
     vector<unsigned char> tep1(tep.begin(),tep.end());
@@ -1379,34 +1380,34 @@ static int ExGetCurTxHash(lua_State *L) {
  */
 static int ExModifyDataDBValueFunc(lua_State *L)
 {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
-	if(!GetDataTableWriteDataDB(L,retdata) ||retdata.size() != 2 )
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    if(!GetDataTableWriteDataDB(L,retdata) ||retdata.size() != 2 )
     {
-    	return RetFalse("ExModifyDataDBValueFunc key err1");
+        return RetFalse("ExModifyDataDBValueFunc key err1");
     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	CRegID scriptid = pVmRunEvn->GetScriptRegID();
-	bool flag = false;
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    CRegID scriptid = pVmRunEvn->GetScriptRegID();
+    bool flag = false;
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
 
-//	int64_t step = 0;
-	CScriptDBOperLog operlog;
-	vector_unsigned_char vTemp;
-	if(scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vTemp)) {
-		if(scriptDB->SetAppData(scriptid,*retdata.at(0),*retdata.at(1).get(),operlog))
-		{
-			shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
-			m_dblog.get()->push_back(operlog);
-			flag = true;
-		}
-	}
+//  int64_t step = 0;
+    CScriptDBOperLog operlog;
+    vector_unsigned_char vTemp;
+    if(scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(),scriptid, *retdata.at(0), vTemp)) {
+        if(scriptDB->SetAppData(scriptid,*retdata.at(0),*retdata.at(1).get(),operlog))
+        {
+            shared_ptr<vector<CScriptDBOperLog> > m_dblog = pVmRunEvn->GetDbLog();
+            m_dblog.get()->push_back(operlog);
+            flag = true;
+        }
+    }
 
-//	step =(((int64_t)(*retdata.at(1)).size())- (int64_t)(vTemp.size()) -1);
+//  step =(((int64_t)(*retdata.at(1)).size())- (int64_t)(vTemp.size()) -1);
     return RetRstBooleanToLua(L,flag);
 }
 
@@ -1414,62 +1415,62 @@ static int ExModifyDataDBValueFunc(lua_State *L)
 static bool GetDataTableWriteOutput(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","GetDataTableWriteOutput is not table\n");
-    	return false;
+        LogPrint("vm","GetDataTableWriteOutput is not table\n");
+        return false;
     }
     double doubleValue = 0;
-	unsigned short len = 0;
+    unsigned short len = 0;
     vector<unsigned char> vBuf ;
     CVmOperate temp;
     memset(&temp,0,sizeof(temp));
     if(!(getNumberInTable(L,(char *)"addrType",doubleValue))){
-    	LogPrint("vm", "addrType get fail\n");
-    	return false;
+        LogPrint("vm", "addrType get fail\n");
+        return false;
     }else{
-    	temp.nacctype = (unsigned char)doubleValue;
+        temp.nacctype = (unsigned char)doubleValue;
     }
-	if(temp.nacctype == 1)
-	{
+    if(temp.nacctype == 1)
+    {
        len = 6;
-	}else if(temp.nacctype == 2){
+    }else if(temp.nacctype == 2){
        len = 34;
-	}else{
-		LogPrint("vm", "error nacctype:%d\n", temp.nacctype);
-		return false;
-	}
+    }else{
+        LogPrint("vm", "error nacctype:%d\n", temp.nacctype);
+        return false;
+    }
     if(!getArrayInTable(L,(char *)"accountIdTbl",len,vBuf))
     {
-    	LogPrint("vm","accountidTbl not table\n");
-    	return false;
+        LogPrint("vm","accountidTbl not table\n");
+        return false;
     }else{
        memcpy(temp.accountid,&vBuf[0],len);
     }
     if(!(getNumberInTable(L,(char *)"operatorType",doubleValue))){
-    	LogPrint("vm", "opeatortype get fail\n");
-    	return false;
+        LogPrint("vm", "opeatortype get fail\n");
+        return false;
     }else{
-    	temp.opeatortype = (unsigned char)doubleValue;
+        temp.opeatortype = (unsigned char)doubleValue;
     }
     if(!(getNumberInTable(L,(char *)"outHeight",doubleValue))){
-    	LogPrint("vm", "outheight get fail\n");
-    	return false;
+        LogPrint("vm", "outheight get fail\n");
+        return false;
     }else{
-    	temp.outheight = (unsigned int)doubleValue;
+        temp.outheight = (unsigned int)doubleValue;
     }
 
-	if(!getArrayInTable(L,(char *)"moneyTbl",sizeof(temp.money),vBuf))
-	{
-		LogPrint("vm","moneyTbl not table\n");
-		return false;
-	}else{
-		memcpy(temp.money,&vBuf[0],sizeof(temp.money));
-	}
+    if(!getArrayInTable(L,(char *)"moneyTbl",sizeof(temp.money),vBuf))
+    {
+        LogPrint("vm","moneyTbl not table\n");
+        return false;
+    }else{
+        memcpy(temp.money,&vBuf[0],sizeof(temp.money));
+    }
 
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << temp;
     vector<unsigned char> tep1(tep.begin(),tep.end());
-	ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
-	return true;
+    ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
+    return true;
 }
 /**
  *bool WriteOutput( const VM_OPERATE* data, const unsigned short conter)
@@ -1478,56 +1479,56 @@ static bool GetDataTableWriteOutput(lua_State *L, vector<std::shared_ptr < std::
  */
 static int ExWriteOutputFunc(lua_State *L)
 {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetDataTableWriteOutput(L,retdata) ||retdata.size() != 1 )
     {
-  		 return RetFalse("para err0");
-  	 }
+         return RetFalse("para err0");
+     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
-	vector<CVmOperate> source;
-	CVmOperate temp;
-	int Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
-	int datadsize = retdata.at(0)->size();
-	int count = datadsize/Size;
-	if(datadsize%Size != 0)
-	{
-//	  assert(0);
-	 return RetFalse("para err1");
-	}
-	CDataStream ss(*retdata.at(0),SER_DISK, CLIENT_VERSION);
+    vector<CVmOperate> source;
+    CVmOperate temp;
+    int Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
+    int datadsize = retdata.at(0)->size();
+    int count = datadsize/Size;
+    if(datadsize%Size != 0)
+    {
+//    assert(0);
+     return RetFalse("para err1");
+    }
+    CDataStream ss(*retdata.at(0),SER_DISK, CLIENT_VERSION);
 
-	while(count--)
-	{
-		ss >> temp;
+    while(count--)
+    {
+        ss >> temp;
       source.push_back(temp);
-	}
-	if(!pVmRunEvn->InsertOutputData(source)) {
-		 return RetFalse("InsertOutput err");
-	}else{
-		/*
-		* 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-		return RetRstBooleanToLua(L,true);
-	}
+    }
+    if(!pVmRunEvn->InsertOutputData(source)) {
+         return RetFalse("InsertOutput err");
+    }else{
+        /*
+        * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
+        return RetRstBooleanToLua(L,true);
+    }
 }
 
 
 static bool GetDataTableGetAppData(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm", "GetDataTableGetAppData is not table\n");
-    	return false;
+        LogPrint("vm", "GetDataTableGetAppData is not table\n");
+        return false;
     }
     vector<unsigned char> vBuf ;
     //取脚本id
     if(!getArrayInTable(L,(char *)"id",6,vBuf))
     {
-    	LogPrint("vm","idTbl not table\n");
-    	return false;
+        LogPrint("vm","idTbl not table\n");
+        return false;
     }else{
        ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
@@ -1535,19 +1536,19 @@ static bool GetDataTableGetAppData(lua_State *L, vector<std::shared_ptr < std::v
     //取key
     string key = "";
     if(!(getStringInTable(L,(char *)"key",key))){
-    	LogPrint("vm","key get fail\n");
-    	return false;
+        LogPrint("vm","key get fail\n");
+        return false;
     }else{
-//		LogPrint("vm", "key:%s\n", key);
+//      LogPrint("vm", "key:%s\n", key);
     }
 
-	vBuf.clear();
-	for(size_t i = 0;i < key.size();i++)
-	{
-		vBuf.insert(vBuf.end(),key.at(i));
-	}
-	ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
-	return true;
+    vBuf.clear();
+    for(size_t i = 0;i < key.size();i++)
+    {
+        vBuf.insert(vBuf.end(),key.at(i));
+    }
+    ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+    return true;
 }
 
 /**
@@ -1558,34 +1559,34 @@ static bool GetDataTableGetAppData(lua_State *L, vector<std::shared_ptr < std::v
  */
 static int ExGetAppDataFunc(lua_State *L)
 {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetDataTableGetAppData(L,retdata) ||retdata.size() != 2 || retdata.at(0).get()->size() != 6)
     {
-    	return RetFalse("ExGetAppDataFunc tep1 err1");
+        return RetFalse("ExGetAppDataFunc tep1 err1");
     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	vector_unsigned_char vValue;
-	CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
-	CRegID scriptid(*retdata.at(0));
+    vector_unsigned_char vValue;
+    CScriptDBViewCache* scriptDB = pVmRunEvn->GetScriptDB();
+    CRegID scriptid(*retdata.at(0));
     int len = 0;
-	if(!scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(), scriptid, *retdata.at(1), vValue))
-	{
-		len = 0;
-	}
-	else
-	{
-	   //3.往函数私有栈里存运算后的结果
-		len = RetRstToLua(L,vValue);
-	}
+    if(!scriptDB->GetAppData(pVmRunEvn->GetComfirHeight(), scriptid, *retdata.at(1), vValue))
+    {
+        len = 0;
+    }
+    else
+    {
+       //3.往函数私有栈里存运算后的结果
+        len = RetRstToLua(L,vValue);
+    }
    /*
-	* 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-	return len;
+    * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
+    return len;
 }
 
 
@@ -1601,33 +1602,33 @@ static int ExGetAppRegIDFunc(lua_State *L)
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
    //1.从lua取参数
    //2.调用C++库函数 执行运算
-	vector_unsigned_char scriptid = pVmRunEvn->GetScriptRegID().GetVec6();
+    vector_unsigned_char scriptid = pVmRunEvn->GetScriptRegID().GetVec6();
    //3.往函数私有栈里存运算后的结果
-	int len = RetRstToLua(L,scriptid);
+    int len = RetRstToLua(L,scriptid);
    /*
-	* 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-	return len; //number of results 告诉Lua返回了几个返回值
+    * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
+    return len; //number of results 告诉Lua返回了几个返回值
 }
 static int ExGetCurTxAccountFunc(lua_State *L)
 {
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
    //1.从lua取参数
    //2.调用C++库函数 执行运算
-	vector_unsigned_char vUserId =pVmRunEvn->GetTxAccount().GetVec6();
+    vector_unsigned_char vUserId =pVmRunEvn->GetTxAccount().GetVec6();
 
    //3.往函数私有栈里存运算后的结果
-	int len = RetRstToLua(L,vUserId);
+    int len = RetRstToLua(L,vUserId);
    /*
     * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-	return len; //number of results 告诉Lua返回了几个返回值
+    return len; //number of results 告诉Lua返回了几个返回值
 }
 
 static int GetCurTxPayAmountFunc(lua_State *L){
@@ -1635,9 +1636,9 @@ static int GetCurTxPayAmountFunc(lua_State *L){
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
-	uint64_t lvalue =pVmRunEvn->GetValue();
+    uint64_t lvalue =pVmRunEvn->GetValue();
 
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << lvalue;
@@ -1645,47 +1646,47 @@ static int GetCurTxPayAmountFunc(lua_State *L){
     int len = RetRstToLua(L,tep1);
     /*
     * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-   	return len; //number of results 告诉Lua返回了几个返回值
+    return len; //number of results 告诉Lua返回了几个返回值
 }
 
 struct S_APP_ID
 {
-	unsigned char idlen;                    //!the len of the tag
-	unsigned char ID[CAppCFund::MAX_TAG_SIZE];     //! the ID for the
+    unsigned char idlen;                    //!the len of the tag
+    unsigned char ID[CAppCFund::MAX_TAG_SIZE];     //! the ID for the
 
-	const vector<unsigned char> GetIdV() const {
-//		assert(sizeof(ID) >= idlen);
-		vector<unsigned char> Id(&ID[0], &ID[idlen]);
-		return (Id);
-	}
+    const vector<unsigned char> GetIdV() const {
+//      assert(sizeof(ID) >= idlen);
+        vector<unsigned char> Id(&ID[0], &ID[idlen]);
+        return (Id);
+    }
 }__attribute((aligned (1)));
 
 static int GetUserAppAccValue(lua_State *L){
 
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","is not table\n");
-    	return 0;
+        LogPrint("vm","is not table\n");
+        return 0;
     }
     double doubleValue = 0;
     vector<unsigned char> vBuf ;
     S_APP_ID accid;
     memset(&accid,0,sizeof(accid));
     if(!(getNumberInTable(L,(char *)"idLen",doubleValue))){
-    	LogPrint("vm","idlen get fail\n");
-    	return 0;
+        LogPrint("vm","idlen get fail\n");
+        return 0;
     }else{
-    	accid.idlen = (unsigned char)doubleValue;
+        accid.idlen = (unsigned char)doubleValue;
     }
     if((accid.idlen < 1) || (accid.idlen > sizeof(accid.ID))){
-    	LogPrint("vm","idlen is err\n");
-    	return 0;
+        LogPrint("vm","idlen is err\n");
+        return 0;
     }
     if(!getArrayInTable(L,(char *)"idValueTbl",accid.idlen,vBuf))
     {
-    	LogPrint("vm","idValueTbl not table\n");
-    	return 0;
+        LogPrint("vm","idValueTbl not table\n");
+        return 0;
     }else{
        memcpy(&accid.ID[0],&vBuf[0],accid.idlen);
     }
@@ -1693,188 +1694,188 @@ static int GetUserAppAccValue(lua_State *L){
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-   	shared_ptr<CAppUserAccout> sptrAcc;
-   	uint64_t valueData = 0 ;
-   	int len = 0;
-   	if(pVmRunEvn->GetAppUserAccout(accid.GetIdV(),sptrAcc))
-	{
-   		valueData = sptrAcc->getllValues();
+    shared_ptr<CAppUserAccout> sptrAcc;
+    uint64_t valueData = 0 ;
+    int len = 0;
+    if(pVmRunEvn->GetAppUserAccout(accid.GetIdV(),sptrAcc))
+    {
+        valueData = sptrAcc->getllValues();
 
-		CDataStream tep(SER_DISK, CLIENT_VERSION);
-		tep << valueData;
-		vector<unsigned char> TMP(tep.begin(),tep.end());
-		len = RetRstToLua(L,TMP);
-	}
+        CDataStream tep(SER_DISK, CLIENT_VERSION);
+        tep << valueData;
+        vector<unsigned char> TMP(tep.begin(),tep.end());
+        len = RetRstToLua(L,TMP);
+    }
     return len;
 }
 
 static bool GetDataTableOutAppOperate(lua_State *L, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
     if(!lua_istable(L,-1))
     {
-    	LogPrint("vm","is not table\n");
-    	return false;
+        LogPrint("vm","is not table\n");
+        return false;
     }
     double doubleValue = 0;
     vector<unsigned char> vBuf ;
-	CAppFundOperate temp;
-	memset(&temp,0,sizeof(temp));
-	if(!(getNumberInTable(L,(char *)"operatorType",doubleValue))){
-		LogPrint("vm","opeatortype get fail\n");
-		return false;
-	}else{
-		temp.opeatortype = (unsigned char)doubleValue;
-	}
-	if(!(getNumberInTable(L,(char *)"outHeight",doubleValue))){
-		LogPrint("vm","outheight get fail\n");
-		return false;
-	}else{
-		temp.outheight = (unsigned int)doubleValue;
-	}
+    CAppFundOperate temp;
+    memset(&temp,0,sizeof(temp));
+    if(!(getNumberInTable(L,(char *)"operatorType",doubleValue))){
+        LogPrint("vm","opeatortype get fail\n");
+        return false;
+    }else{
+        temp.opeatortype = (unsigned char)doubleValue;
+    }
+    if(!(getNumberInTable(L,(char *)"outHeight",doubleValue))){
+        LogPrint("vm","outheight get fail\n");
+        return false;
+    }else{
+        temp.outheight = (unsigned int)doubleValue;
+    }
 
     if(!getArrayInTable(L,(char *)"moneyTbl",sizeof(temp.mMoney),vBuf))
     {
-    	LogPrint("vm","moneyTbl not table\n");
-    	return false;
+        LogPrint("vm","moneyTbl not table\n");
+        return false;
     }else{
        memcpy(&temp.mMoney,&vBuf[0],sizeof(temp.mMoney));
     }
     if(!(getNumberInTable(L,(char *)"userIdLen",doubleValue))){
-    	LogPrint("vm","appuserIDlen get fail\n");
-    	return false;
+        LogPrint("vm","appuserIDlen get fail\n");
+        return false;
     }else{
-    	temp.appuserIDlen = (unsigned char)doubleValue;
+        temp.appuserIDlen = (unsigned char)doubleValue;
     }
     if((temp.appuserIDlen < 1) || (temp.appuserIDlen > sizeof(temp.vAppuser))){
-    	LogPrint("vm","appuserIDlen is err\n");
-    	return false;
+        LogPrint("vm","appuserIDlen is err\n");
+        return false;
     }
-	if(!getArrayInTable(L,(char *)"userIdTbl",temp.appuserIDlen,vBuf))
-	{
-		LogPrint("vm","useridTbl not table\n");
-		return false;
-	}else{
-		memcpy(temp.vAppuser,&vBuf[0],temp.appuserIDlen);
-	}
-    if(!(getNumberInTable(L,(char *)"fundTagLen",doubleValue))){
-		LogPrint("vm","FundTaglen get fail\n");
-		return false;
-    }else{
-    	temp.FundTaglen = (unsigned char)doubleValue;
-    }
-	if((temp.FundTaglen > 0) && (temp.FundTaglen <= sizeof(temp.vFundTag)))
+    if(!getArrayInTable(L,(char *)"userIdTbl",temp.appuserIDlen,vBuf))
     {
-		if(!getArrayInTable(L,(char *)"fundTagTbl",temp.FundTaglen,vBuf))
-		{
-			LogPrint("vm","FundTagTbl not table\n");
-			return false;
-		}else{
-			memcpy(temp.vFundTag,&vBuf[0],temp.FundTaglen);
-		}
+        LogPrint("vm","useridTbl not table\n");
+        return false;
+    }else{
+        memcpy(temp.vAppuser,&vBuf[0],temp.appuserIDlen);
+    }
+    if(!(getNumberInTable(L,(char *)"fundTagLen",doubleValue))){
+        LogPrint("vm","FundTaglen get fail\n");
+        return false;
+    }else{
+        temp.FundTaglen = (unsigned char)doubleValue;
+    }
+    if((temp.FundTaglen > 0) && (temp.FundTaglen <= sizeof(temp.vFundTag)))
+    {
+        if(!getArrayInTable(L,(char *)"fundTagTbl",temp.FundTaglen,vBuf))
+        {
+            LogPrint("vm","FundTagTbl not table\n");
+            return false;
+        }else{
+            memcpy(temp.vFundTag,&vBuf[0],temp.FundTaglen);
+        }
     }
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << temp;
     vector<unsigned char> tep1(tep.begin(),tep.end());
-	ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
-	return true;
+    ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
+    return true;
 }
 static int GetUserAppAccFoudWithTag(lua_State *L){
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
-	unsigned int Size(0);
-	CAppFundOperate temp;
-	Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    unsigned int Size(0);
+    CAppFundOperate temp;
+    Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
 
     if(!GetDataTableOutAppOperate(L,retdata) ||retdata.size() != 1
-    	|| retdata.at(0).get()->size() !=Size)
+        || retdata.at(0).get()->size() !=Size)
     {
-    	return RetFalse("GetUserAppAccFoudWithTag para err0");
+        return RetFalse("GetUserAppAccFoudWithTag para err0");
     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
     CDataStream ss(*retdata.at(0),SER_DISK, CLIENT_VERSION);
     CAppFundOperate userfund;
     ss>>userfund;
 
-   	shared_ptr<CAppUserAccout> sptrAcc;
+    shared_ptr<CAppUserAccout> sptrAcc;
     CAppCFund fund;
-	int len = 0;
-	if(pVmRunEvn->GetAppUserAccout(userfund.GetAppUserV(),sptrAcc))
-	{
-		if(!sptrAcc->GetAppCFund(fund,userfund.GetFundTagV(),userfund.outheight))	{
-			return RetFalse("GetUserAppAccFoudWithTag get fail");
-		}
-		CDataStream tep(SER_DISK, CLIENT_VERSION);
-		tep << fund.getvalue() ;
-		vector<unsigned char> TMP(tep.begin(),tep.end());
-		len = RetRstToLua(L,TMP);
-	}
+    int len = 0;
+    if(pVmRunEvn->GetAppUserAccout(userfund.GetAppUserV(),sptrAcc))
+    {
+        if(!sptrAcc->GetAppCFund(fund,userfund.GetFundTagV(),userfund.outheight))   {
+            return RetFalse("GetUserAppAccFoudWithTag get fail");
+        }
+        CDataStream tep(SER_DISK, CLIENT_VERSION);
+        tep << fund.getvalue() ;
+        vector<unsigned char> TMP(tep.begin(),tep.end());
+        len = RetRstToLua(L,TMP);
+    }
     return len;
 }
 
 static bool GetDataTableAssetOperate(lua_State *L, int nIndex, vector<std::shared_ptr < std::vector<unsigned char> > > &ret) {
     if(!lua_istable(L,nIndex))
     {
-    	LogPrint("vm","is not table\n");
-    	return false;
+        LogPrint("vm","is not table\n");
+        return false;
     }
     double doubleValue = 0;
     vector<unsigned char> vBuf ;
     CAssetOperate temp;
-	memset(&temp,0,sizeof(temp));
+    memset(&temp,0,sizeof(temp));
 
     if(!getArrayInTable(L,(char *)"toAddrTbl",34,vBuf))
     {
-    	LogPrint("vm","toAddrTbl not table\n");
-    	return false;
+        LogPrint("vm","toAddrTbl not table\n");
+        return false;
     }else{
 
-    	ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
+        ret.push_back(std::make_shared<vector<unsigned char>>(vBuf.begin(), vBuf.end()));
     }
 
-	if(!(getNumberInTable(L,(char *)"outHeight",doubleValue))){
-		LogPrint("vm","outheight get fail\n");
-		return false;
-	}else{
-		temp.outheight = (unsigned int)doubleValue;
+    if(!(getNumberInTable(L,(char *)"outHeight",doubleValue))){
+        LogPrint("vm","outheight get fail\n");
+        return false;
+    }else{
+        temp.outheight = (unsigned int)doubleValue;
 
-		printf("height:%d", temp.outheight);
-	}
+        printf("height:%d", temp.outheight);
+    }
 
     if(!getArrayInTable(L,(char *)"moneyTbl",sizeof(temp.mMoney),vBuf))
     {
-    	LogPrint("vm","moneyTbl not table\n");
-    	return false;
+        LogPrint("vm","moneyTbl not table\n");
+        return false;
     }else{
        memcpy(&temp.mMoney,&vBuf[0],sizeof(temp.mMoney));
     }
     if(!(getNumberInTable(L,(char *)"fundTagLen",doubleValue))){
-		LogPrint("vm","FundTaglen get fail\n");
-		return false;
+        LogPrint("vm","FundTaglen get fail\n");
+        return false;
     }else{
-    	temp.FundTaglen = (unsigned char)doubleValue;
+        temp.FundTaglen = (unsigned char)doubleValue;
     }
-	if((temp.FundTaglen > 0) && (temp.FundTaglen <= sizeof(temp.vFundTag)))
+    if((temp.FundTaglen > 0) && (temp.FundTaglen <= sizeof(temp.vFundTag)))
     {
-		if(!getArrayInTable(L,(char *)"fundTagTbl",temp.FundTaglen,vBuf))
-		{
-			LogPrint("vm","FundTagTbl not table\n");
-			return false;
-		}else{
-			memcpy(temp.vFundTag,&vBuf[0],temp.FundTaglen);
-		}
+        if(!getArrayInTable(L,(char *)"fundTagTbl",temp.FundTaglen,vBuf))
+        {
+            LogPrint("vm","FundTagTbl not table\n");
+            return false;
+        }else{
+            memcpy(temp.vFundTag,&vBuf[0],temp.FundTaglen);
+        }
     }
     CDataStream tep(SER_DISK, CLIENT_VERSION);
     tep << temp;
     vector<unsigned char> tep1(tep.begin(),tep.end());
-	ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
-	return true;
+    ret.insert(ret.end(),std::make_shared<vector<unsigned char>>(tep1.begin(), tep1.end()));
+    return true;
 }
 
 /**
@@ -1885,197 +1886,197 @@ static bool GetDataTableAssetOperate(lua_State *L, int nIndex, vector<std::share
  */
 static int ExWriteOutAppOperateFunc(lua_State *L)
 {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
-	CAppFundOperate temp;
-	unsigned int Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
+    CAppFundOperate temp;
+    unsigned int Size = ::GetSerializeSize(temp, SER_NETWORK, PROTOCOL_VERSION);
 
-	if(!GetDataTableOutAppOperate(L,retdata) ||retdata.size() != 1 || (retdata.at(0).get()->size()%Size) != 0 )
+    if(!GetDataTableOutAppOperate(L,retdata) ||retdata.size() != 1 || (retdata.at(0).get()->size()%Size) != 0 )
     {
-  		 return RetFalse("ExWriteOutAppOperateFunc para err1");
-  	 }
+         return RetFalse("ExWriteOutAppOperateFunc para err1");
+     }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	int count = retdata.at(0).get()->size()/Size;
-	CDataStream ss(*retdata.at(0),SER_DISK, CLIENT_VERSION);
+    int count = retdata.at(0).get()->size()/Size;
+    CDataStream ss(*retdata.at(0),SER_DISK, CLIENT_VERSION);
 
-	int64_t step =-1;
-	while(count--)
-	{
-		ss >> temp;
-		if(pVmRunEvn->GetComfirHeight() > nFreezeBlackAcctHeight && temp.mMoney < 0) //不能小于0,防止 上层传错金额小于20150904
-		{
-			return RetFalse("ExWriteOutAppOperateFunc para err2");
-		}
-		pVmRunEvn->InsertOutAPPOperte(temp.GetAppUserV(),temp);
-		step +=Size;
-	}
+    int64_t step =-1;
+    while(count--)
+    {
+        ss >> temp;
+        if(pVmRunEvn->GetComfirHeight() > nFreezeBlackAcctHeight && temp.mMoney < 0) //不能小于0,防止 上层传错金额小于20150904
+        {
+            return RetFalse("ExWriteOutAppOperateFunc para err2");
+        }
+        pVmRunEvn->InsertOutAPPOperte(temp.GetAppUserV(),temp);
+        step +=Size;
+    }
 
-	/*
-	* 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
-	return RetRstBooleanToLua(L,true);
+    /*
+    * 每个函数里的Lua栈是私有的,当把返回值压入Lua栈以后，该栈会自动被清空*/
+    return RetRstBooleanToLua(L,true);
 }
 static int ExGetBase58AddrFunc(lua_State *L){
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
-	if(!GetArray(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() != 6)
-	{
-		return RetFalse("ExGetBase58AddrFunc para err0");
-	}
+    if(!GetArray(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() != 6)
+    {
+        return RetFalse("ExGetBase58AddrFunc para err0");
+    }
 
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 /*
-	vector<unsigned char> recvkey;
-	recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
+    vector<unsigned char> recvkey;
+    recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
 
-	std::string recvaddr( recvkey.begin(), recvkey.end() );
+    std::string recvaddr( recvkey.begin(), recvkey.end() );
 
-	for(int i = 0; i < recvkey.size(); i++)
-		LogPrint("vm", "==============%02X\n", recvkey[i]);
+    for(int i = 0; i < recvkey.size(); i++)
+        LogPrint("vm", "==============%02X\n", recvkey[i]);
 
-	vector<unsigned char> tmp;
-	for(int i = recvkey.size() - 1; i >=0 ; i--)
-		tmp.push_back(recvkey[i]);
+    vector<unsigned char> tmp;
+    for(int i = recvkey.size() - 1; i >=0 ; i--)
+        tmp.push_back(recvkey[i]);
 */
-	 CKeyID addrKeyId;
-	 if (!GetKeyId(*pVmRunEvn->GetCatchView(),*retdata.at(0).get(), addrKeyId)) {
-		    return RetFalse("ExGetBase58AddrFunc para err1");
-	 }
-	 string wiccaddr = addrKeyId.ToAddress();
+     CKeyID addrKeyId;
+     if (!GetKeyId(*pVmRunEvn->GetCatchView(),*retdata.at(0).get(), addrKeyId)) {
+            return RetFalse("ExGetBase58AddrFunc para err1");
+     }
+     string wiccaddr = addrKeyId.ToAddress();
 
-	 vector<unsigned char> vTemp;
-	 vTemp.assign(wiccaddr.c_str(), wiccaddr.c_str()+wiccaddr.length());
-	 return RetRstToLua(L,vTemp);
+     vector<unsigned char> vTemp;
+     vTemp.assign(wiccaddr.c_str(), wiccaddr.c_str()+wiccaddr.length());
+     return RetRstToLua(L,vTemp);
 }
 
 static int ExTransferContactAsset(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
     if(!GetArray(L,retdata) ||retdata.size() != 1 || retdata.at(0).get()->size() != 34)
     {
-    	return RetFalse(string(__FUNCTION__)+"para  err !");
+        return RetFalse(string(__FUNCTION__)+"para  err !");
     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
-	vector<unsigned char> sendkey;
-	vector<unsigned char> recvkey;
-	CRegID script = pVmRunEvn->GetScriptRegID();
+    vector<unsigned char> sendkey;
+    vector<unsigned char> recvkey;
+    CRegID script = pVmRunEvn->GetScriptRegID();
 
-	CRegID sendRegID =pVmRunEvn->GetTxAccount();
-	CKeyID SendKeyID = sendRegID.getKeyID(*pVmRunEvn->GetCatchView());
-	string addr = SendKeyID.ToAddress();
-	sendkey.assign(addr.c_str(),addr.c_str()+addr.length());
+    CRegID sendRegID =pVmRunEvn->GetTxAccount();
+    CKeyID SendKeyID = sendRegID.getKeyID(*pVmRunEvn->GetCatchView());
+    string addr = SendKeyID.ToAddress();
+    sendkey.assign(addr.c_str(),addr.c_str()+addr.length());
 
-	recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
+    recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
 
-	std::string recvaddr( recvkey.begin(), recvkey.end() );
-	if(addr == recvaddr)
-	{
-		LogPrint("vm", "%s\n", "send addr and recv addr is same !");
-		return RetFalse(string(__FUNCTION__)+"send addr and recv addr is same !");
-	}
+    std::string recvaddr( recvkey.begin(), recvkey.end() );
+    if(addr == recvaddr)
+    {
+        LogPrint("vm", "%s\n", "send addr and recv addr is same !");
+        return RetFalse(string(__FUNCTION__)+"send addr and recv addr is same !");
+    }
 
-	CKeyID RecvKeyID;
-	bool bValid = GetKeyId(*pVmRunEvn->GetCatchView(), recvkey, RecvKeyID);
-	if(!bValid)
-	{
-		LogPrint("vm", "%s\n", "recv addr is not valid !");
-		return RetFalse(string(__FUNCTION__)+"recv addr is not valid !");
-	}
+    CKeyID RecvKeyID;
+    bool bValid = GetKeyId(*pVmRunEvn->GetCatchView(), recvkey, RecvKeyID);
+    if(!bValid)
+    {
+        LogPrint("vm", "%s\n", "recv addr is not valid !");
+        return RetFalse(string(__FUNCTION__)+"recv addr is not valid !");
+    }
 
-	std::shared_ptr<CAppUserAccout> temp = std::make_shared<CAppUserAccout>();
-	CScriptDBViewCache* pContractScript = pVmRunEvn->GetScriptDB();
+    std::shared_ptr<CAppUserAccout> temp = std::make_shared<CAppUserAccout>();
+    CScriptDBViewCache* pContractScript = pVmRunEvn->GetScriptDB();
 
-	if (!pContractScript->GetScriptAcc(script, sendkey, *temp.get())) {
-		return RetFalse(string(__FUNCTION__)+"para  err3 !");
-	}
+    if (!pContractScript->GetScriptAcc(script, sendkey, *temp.get())) {
+        return RetFalse(string(__FUNCTION__)+"para  err3 !");
+    }
 
-	temp.get()->AutoMergeFreezeToFree(chainActive.Tip()->nHeight);
+    temp.get()->AutoMergeFreezeToFree(chainActive.Tip()->nHeight);
 
-	uint64_t nMoney = temp.get()->getllValues();
+    uint64_t nMoney = temp.get()->getllValues();
 
-	int i = 0;
-	CAppFundOperate op;
-	memset(&op, 0, sizeof(op));
+    int i = 0;
+    CAppFundOperate op;
+    memset(&op, 0, sizeof(op));
 
-	if(nMoney > 0) {
-		op.mMoney = nMoney;
-		op.outheight = 0;
-		op.opeatortype = SUB_FREE_OP;
-		op.appuserIDlen = sendkey.size();
-		for (i = 0; i < op.appuserIDlen; i++) {
-			op.vAppuser[i] = sendkey[i];
-		}
+    if(nMoney > 0) {
+        op.mMoney = nMoney;
+        op.outheight = 0;
+        op.opeatortype = SUB_FREE_OP;
+        op.appuserIDlen = sendkey.size();
+        for (i = 0; i < op.appuserIDlen; i++) {
+            op.vAppuser[i] = sendkey[i];
+        }
 
-		pVmRunEvn->InsertOutAPPOperte(sendkey, op);
+        pVmRunEvn->InsertOutAPPOperte(sendkey, op);
 
-		op.opeatortype = ADD_FREE_OP;
-		op.appuserIDlen = recvkey.size();
-		for (i = 0; i < op.appuserIDlen; i++) {
-			op.vAppuser[i] = recvkey[i];
-		}
-		pVmRunEvn->InsertOutAPPOperte(recvkey, op);
-	}
+        op.opeatortype = ADD_FREE_OP;
+        op.appuserIDlen = recvkey.size();
+        for (i = 0; i < op.appuserIDlen; i++) {
+            op.vAppuser[i] = recvkey[i];
+        }
+        pVmRunEvn->InsertOutAPPOperte(recvkey, op);
+    }
 
-	vector<CAppCFund> vTemp = temp.get()->getFreezedFund();
-	for(auto fund : vTemp)
-	{
-		op.mMoney = fund.getvalue();
-		op.outheight = fund.getheight();
-		op.opeatortype = SUB_TAG_OP;
-		op.appuserIDlen = sendkey.size();
-		for (i = 0; i < op.appuserIDlen; i++) {
-			op.vAppuser[i] = sendkey[i];
-		}
+    vector<CAppCFund> vTemp = temp.get()->getFreezedFund();
+    for(auto fund : vTemp)
+    {
+        op.mMoney = fund.getvalue();
+        op.outheight = fund.getheight();
+        op.opeatortype = SUB_TAG_OP;
+        op.appuserIDlen = sendkey.size();
+        for (i = 0; i < op.appuserIDlen; i++) {
+            op.vAppuser[i] = sendkey[i];
+        }
 
-		op.FundTaglen = fund.GetTag().size();
-		for(i = 0; i < op.FundTaglen; i++) {
-			op.vFundTag[i] = fund.GetTag()[i];
-		}
+        op.FundTaglen = fund.GetTag().size();
+        for(i = 0; i < op.FundTaglen; i++) {
+            op.vFundTag[i] = fund.GetTag()[i];
+        }
 
-		pVmRunEvn->InsertOutAPPOperte(sendkey, op);
+        pVmRunEvn->InsertOutAPPOperte(sendkey, op);
 
-		op.opeatortype = ADD_TAG_OP;
-		op.appuserIDlen = recvkey.size();
-		for (i = 0; i < op.appuserIDlen; i++) {
-			op.vAppuser[i] = recvkey[i];
-		}
+        op.opeatortype = ADD_TAG_OP;
+        op.appuserIDlen = recvkey.size();
+        for (i = 0; i < op.appuserIDlen; i++) {
+            op.vAppuser[i] = recvkey[i];
+        }
 
-		pVmRunEvn->InsertOutAPPOperte(recvkey, op);
-	}
+        pVmRunEvn->InsertOutAPPOperte(recvkey, op);
+    }
 
-	return RetRstBooleanToLua(L, true);
+    return RetRstBooleanToLua(L, true);
 
 }
 
 static int ExTransferSomeAsset(lua_State *L) {
-	vector<std::shared_ptr < vector<unsigned char> > > retdata;
+    vector<std::shared_ptr < vector<unsigned char> > > retdata;
 
-	unsigned int Size(0);
-	CAssetOperate tempAsset;
-	Size = ::GetSerializeSize(tempAsset, SER_NETWORK, PROTOCOL_VERSION);
+    unsigned int Size(0);
+    CAssetOperate tempAsset;
+    Size = ::GetSerializeSize(tempAsset, SER_NETWORK, PROTOCOL_VERSION);
 
     if(!GetDataTableAssetOperate(L, -1, retdata) ||retdata.size() != 2|| (retdata.at(1).get()->size()%Size) != 0 || retdata.at(0).get()->size() != 34)
     {
-			return RetFalse(string(__FUNCTION__)+"para err !");
+            return RetFalse(string(__FUNCTION__)+"para err !");
     }
     CVmRunEvn* pVmRunEvn = GetVmRunEvn(L);
     if(NULL == pVmRunEvn)
     {
-    	return RetFalse("pVmRunEvn is NULL");
+        return RetFalse("pVmRunEvn is NULL");
     }
 
     CDataStream ss(*retdata.at(1),SER_DISK, CLIENT_VERSION);
@@ -2083,152 +2084,151 @@ static int ExTransferSomeAsset(lua_State *L) {
     ss>>assetOp;
 
     vector<unsigned char> sendkey;
-	vector<unsigned char> recvkey;
-	CRegID script = pVmRunEvn->GetScriptRegID();
+    vector<unsigned char> recvkey;
+    CRegID script = pVmRunEvn->GetScriptRegID();
 
-	CRegID sendRegID = pVmRunEvn->GetTxAccount();
-	CKeyID SendKeyID = sendRegID.getKeyID(*pVmRunEvn->GetCatchView());
-	string addr = SendKeyID.ToAddress();
-	sendkey.assign(addr.c_str(), addr.c_str() + addr.length());
+    CRegID sendRegID = pVmRunEvn->GetTxAccount();
+    CKeyID SendKeyID = sendRegID.getKeyID(*pVmRunEvn->GetCatchView());
+    string addr = SendKeyID.ToAddress();
+    sendkey.assign(addr.c_str(), addr.c_str() + addr.length());
 
-	recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
+    recvkey.assign(retdata.at(0).get()->begin(), retdata.at(0).get()->end());
 
-	std::string recvaddr( recvkey.begin(), recvkey.end() );
-	if(addr == recvaddr)
-	{
-		LogPrint("vm", "%s\n", "send addr and recv addr is same !");
-		return RetFalse(string(__FUNCTION__)+"send addr and recv addr is same !");
-	}
+    std::string recvaddr( recvkey.begin(), recvkey.end() );
+    if(addr == recvaddr)
+    {
+        LogPrint("vm", "%s\n", "send addr and recv addr is same !");
+        return RetFalse(string(__FUNCTION__)+"send addr and recv addr is same !");
+    }
 
-	CKeyID RecvKeyID;
-	bool bValid = GetKeyId(*pVmRunEvn->GetCatchView(), recvkey, RecvKeyID);
-	if(!bValid)
-	{
-		LogPrint("vm", "%s\n", "recv addr is not valid !");
-		return RetFalse(string(__FUNCTION__)+"recv addr is not valid !");
-	}
+    CKeyID RecvKeyID;
+    bool bValid = GetKeyId(*pVmRunEvn->GetCatchView(), recvkey, RecvKeyID);
+    if(!bValid)
+    {
+        LogPrint("vm", "%s\n", "recv addr is not valid !");
+        return RetFalse(string(__FUNCTION__)+"recv addr is not valid !");
+    }
 
-	uint64_t uTransferMoney = assetOp.GetUint64Value();
-	if(0 == uTransferMoney)
-	{
-		return RetFalse(string(__FUNCTION__)+"Transfer Money is not valid !");
-	}
+    uint64_t uTransferMoney = assetOp.GetUint64Value();
+    if(0 == uTransferMoney)
+    {
+        return RetFalse(string(__FUNCTION__)+"Transfer Money is not valid !");
+    }
 
-	int nHeight = assetOp.getheight();
-	if(nHeight < 0) {
-		return RetFalse(string(__FUNCTION__)+"outHeight is not valid !");
-	}
+    int nHeight = assetOp.getheight();
+    if(nHeight < 0) {
+        return RetFalse(string(__FUNCTION__)+"outHeight is not valid !");
+    }
 
-	int i = 0;
-	CAppFundOperate op;
-	memset(&op, 0, sizeof(op));
-	vector<unsigned char> vtag = assetOp.GetFundTagV();
-	op.FundTaglen = vtag.size();
+    int i = 0;
+    CAppFundOperate op;
+    memset(&op, 0, sizeof(op));
+    vector<unsigned char> vtag = assetOp.GetFundTagV();
+    op.FundTaglen = vtag.size();
 
-	for(i = 0; i < op.FundTaglen; i++) {
-		op.vFundTag[i] = vtag[i];
-	}
+    for(i = 0; i < op.FundTaglen; i++) {
+        op.vFundTag[i] = vtag[i];
+    }
 
-	op.mMoney = uTransferMoney;
-	op.outheight = nHeight;
-	op.appuserIDlen = sendkey.size();
+    op.mMoney = uTransferMoney;
+    op.outheight = nHeight;
+    op.appuserIDlen = sendkey.size();
 
-	for (i = 0; i < op.appuserIDlen; i++) {
-		op.vAppuser[i] = sendkey[i];
-	}
-	if (nHeight > 0)
-		op.opeatortype = SUB_TAG_OP;
-	else
-		op.opeatortype = SUB_FREE_OP;
-	pVmRunEvn->InsertOutAPPOperte(sendkey, op);
+    for (i = 0; i < op.appuserIDlen; i++) {
+        op.vAppuser[i] = sendkey[i];
+    }
+    if (nHeight > 0)
+        op.opeatortype = SUB_TAG_OP;
+    else
+        op.opeatortype = SUB_FREE_OP;
+    pVmRunEvn->InsertOutAPPOperte(sendkey, op);
 
-	if (nHeight > 0)
-		op.opeatortype = ADD_TAG_OP;
-	else
-		op.opeatortype = ADD_FREE_OP;
-	op.appuserIDlen = recvkey.size();
-	for (i = 0; i < op.appuserIDlen; i++) {
-		op.vAppuser[i] = recvkey[i];
-	}
-	pVmRunEvn->InsertOutAPPOperte(recvkey, op);
+    if (nHeight > 0)
+        op.opeatortype = ADD_TAG_OP;
+    else
+        op.opeatortype = ADD_FREE_OP;
+    op.appuserIDlen = recvkey.size();
+    for (i = 0; i < op.appuserIDlen; i++) {
+        op.vAppuser[i] = recvkey[i];
+    }
+    pVmRunEvn->InsertOutAPPOperte(recvkey, op);
 
-	return RetRstBooleanToLua(L, true);
+    return RetRstBooleanToLua(L, true);
 
 }
 
 static int ExGetBlockTimestamp(lua_State *L) {
-	int height = 0;
+    int height = 0;
     if(!GetDataInt(L,height)){
-    	return RetFalse("ExGetBlcokTimestamp para err1");
+        return RetFalse("ExGetBlcokTimestamp para err1");
     }
 
     if(height <= 0) {
-    	height = chainActive.Height() + height;
+        height = chainActive.Height() + height;
         if(height < 0) {
-        	return RetFalse("ExGetBlcokTimestamp para err2");
+            return RetFalse("ExGetBlcokTimestamp para err2");
         }
     }
 
 
-	CBlockIndex *pindex = chainActive[height];
-	if(!pindex) {
-		return RetFalse("ExGetBlcokTimestamp get time stamp error");
-	}
+    CBlockIndex *pindex = chainActive[height];
+    if(!pindex) {
+        return RetFalse("ExGetBlcokTimestamp get time stamp error");
+    }
 
-	if (lua_checkstack(L, sizeof(lua_Integer))) {
-		lua_pushinteger(L, (lua_Integer) pindex->nTime);
-		return 1;
-	}
+    if (lua_checkstack(L, sizeof(lua_Integer))) {
+        lua_pushinteger(L, (lua_Integer) pindex->nTime);
+        return 1;
+    }
 
-	LogPrint("vm", "%s\r\n", "ExGetBlcokTimestamp stack overflow");
-	return 0;
+    LogPrint("vm", "%s\n", "ExGetBlcokTimestamp stack overflow");
+    return 0;
 }
 
-static const luaL_Reg mylib[] = { //
-		{"Int64Mul", ExInt64MulFunc },			//
-		{"Int64Add", ExInt64AddFunc },			//
-		{"Int64Sub", ExInt64SubFunc },			//
-		{"Int64Div", ExInt64DivFunc },			//
-		{"Sha256", ExSha256Func },			//
-		{"Des", ExDesFunc },			    //
-		{"VerifySignature", ExVerifySignatureFunc },   //
-		{"LogPrint", ExLogPrintFunc },         //
-		{"GetTxContracts",ExGetTxContractsFunc},            //
-		
-		{"GetTxAccounts",ExGetTxAccountsFunc},
-		{"GetAccountPublickey",ExGetAccountPublickeyFunc},
-		{"QueryAccountBalance",ExQueryAccountBalanceFunc},
-		{"GetTxConfirmHeight",ExGetTxConfirmHeightFunc},
-		{"GetTxConFirmHeight",ExGetTxConfirmHeightFunc}, //for backward compatibility
-		{"GetBlockHash",ExGetBlockHashFunc},
+static const luaL_Reg mylib[] = {
+    {"Int64Mul", ExInt64MulFunc},
+    {"Int64Add", ExInt64AddFunc},
+    {"Int64Sub", ExInt64SubFunc},
+    {"Int64Div", ExInt64DivFunc},
+    {"Sha256", ExSha256Func},
+    {"Des", ExDesFunc},
+    {"VerifySignature", ExVerifySignatureFunc},
+    {"LogPrint", ExLogPrintFunc},
+    {"GetTxContracts", ExGetTxContractsFunc},
+    {"GetTxRegID", ExGetTxRegIDFunc},
+    {"GetAccountPublickey", ExGetAccountPublickeyFunc},
+    {"QueryAccountBalance", ExQueryAccountBalanceFunc},
+    {"GetTxConfirmHeight", ExGetTxConfirmHeightFunc},
+    {"GetTxConFirmHeight", ExGetTxConfirmHeightFunc}, //for backward compatibility
+    {"GetBlockHash", ExGetBlockHashFunc},
 
-		{"GetCurRunEnvHeight",ExGetCurRunEnvHeightFunc},
-		{"WriteData",ExWriteDataDBFunc},
-		{"DeleteData",ExDeleteDataDBFunc},
-		{"ReadData",ExReadDataValueDBFunc},
-		{"GetCurTxHash",ExGetCurTxHash},
-		{"ModifyData",ExModifyDataDBValueFunc},
+    {"GetCurRunEnvHeight", ExGetCurRunEnvHeightFunc},
+    {"WriteData", ExWriteDataDBFunc},
+    {"DeleteData", ExDeleteDataDBFunc},
+    {"ReadData", ExReadDataValueDBFunc},
+    {"GetCurTxHash", ExGetCurTxHash},
+    {"ModifyData", ExModifyDataDBValueFunc},
 
-		{"WriteOutput",ExWriteOutputFunc},
-		{"GetScriptData",ExGetAppDataFunc},
-		{"GetScriptID",ExGetAppRegIDFunc},
-		{"GetCurTxAccount",ExGetCurTxAccountFunc},
-		{"GetCurTxPayAmount",GetCurTxPayAmountFunc},
+    {"WriteOutput", ExWriteOutputFunc},
+    {"GetScriptData", ExGetAppDataFunc},
+    {"GetScriptID", ExGetAppRegIDFunc},
+    {"GetCurTxAccount", ExGetCurTxAccountFunc},
+    {"GetCurTxPayAmount", GetCurTxPayAmountFunc},
 
-		{"GetUserAppAccValue",GetUserAppAccValue},
-		{"GetUserAppAccFoudWithTag",GetUserAppAccFoudWithTag},
-		{"WriteOutAppOperate",ExWriteOutAppOperateFunc},
+    {"GetUserAppAccValue", GetUserAppAccValue},
+    {"GetUserAppAccFoudWithTag", GetUserAppAccFoudWithTag},
+    {"WriteOutAppOperate", ExWriteOutAppOperateFunc},
 
-		{"GetBase58Addr",ExGetBase58AddrFunc},
-		{"ByteToInteger",ExByteToIntegerFunc},
-		{"IntegerToByte4",ExIntegerToByte4Func},
-		{"IntegerToByte8",ExIntegerToByte8Func},
-		{"TransferContactAsset", ExTransferContactAsset},
-		{"TransferSomeAsset", ExTransferSomeAsset},
-		{"GetBlockTimestamp", ExGetBlockTimestamp},
-		{NULL,NULL}
+    {"GetBase58Addr", ExGetBase58AddrFunc},
+    {"ByteToInteger", ExByteToIntegerFunc},
+    {"IntegerToByte4", ExIntegerToByte4Func},
+    {"IntegerToByte8", ExIntegerToByte8Func},
+    {"TransferContactAsset", ExTransferContactAsset},
+    {"TransferSomeAsset", ExTransferSomeAsset},
+    {"GetBlockTimestamp", ExGetBlockTimestamp},
+    {NULL, NULL}
 
-		};
+};
 
 /*
  * 注册一个新Lua模块*/
@@ -2238,7 +2238,7 @@ extern "C" __declspec(dllexport)int luaopen_mylib(lua_State *L)
 LUAMOD_API int luaopen_mylib(lua_State *L)
 #endif
 {
-	luaL_newlib(L,mylib);//生成一个table,把mylibs所有函数填充进去
-	return 1;
+    luaL_newlib(L,mylib);//生成一个table,把mylibs所有函数填充进去
+    return 1;
 }
 

--- a/src/vm/vmrunevn.cpp
+++ b/src/vm/vmrunevn.cpp
@@ -15,522 +15,522 @@
 
 #define MAX_OUTPUT_COUNT 100
 CVmRunEvn::CVmRunEvn() {
-	RawAccont.clear();
-	NewAccont.clear();
-	RawAppUserAccout.clear();
-	NewAppUserAccout.clear();
-	RunTimeHeight = 0;
-	m_ScriptDBTip = NULL;
-	m_view = NULL;
-	m_dblog = std::make_shared<std::vector<CScriptDBOperLog> >();
-	isCheckAccount = false;
+    RawAccont.clear();
+    NewAccont.clear();
+    RawAppUserAccout.clear();
+    NewAppUserAccout.clear();
+    RunTimeHeight = 0;
+    m_ScriptDBTip = NULL;
+    m_view = NULL;
+    m_dblog = std::make_shared<std::vector<CScriptDBOperLog> >();
+    isCheckAccount = false;
 }
 vector<shared_ptr<CAccount> > &CVmRunEvn::GetRawAccont() {
-	return RawAccont;
+    return RawAccont;
 }
 vector<shared_ptr<CAccount> > &CVmRunEvn::GetNewAccont() {
-	return NewAccont;
+    return NewAccont;
 }
 vector<shared_ptr<CAppUserAccout>> &CVmRunEvn::GetNewAppUserAccount()
 {
-	return NewAppUserAccout;
+    return NewAppUserAccout;
 }
 
 vector<shared_ptr<CAppUserAccout>> &CVmRunEvn::GetRawAppUserAccount()
 {
-	return RawAppUserAccout;
+    return RawAppUserAccout;
 }
 
 
 bool CVmRunEvn::intial(shared_ptr<CBaseTransaction> & Tx, CAccountViewCache& view, int nheight) {
 
-	m_output.clear();
-	listTx = Tx;
-	RunTimeHeight = nheight;
-	m_view = &view;
-	vector<unsigned char> vScript;
+    m_output.clear();
+    listTx = Tx;
+    RunTimeHeight = nheight;
+    m_view = &view;
+    vector<unsigned char> vScript;
 
-	if (Tx.get()->nTxType != CONTRACT_TX) {
-		LogPrint("ERROR", "%s\r\n", "err param");
-//		assert(0);
-		return false;
-	}
+    if (Tx.get()->nTxType != CONTRACT_TX) {
+        LogPrint("ERROR", "%s\r\n", "err param");
+//      assert(0);
+        return false;
+    }
 
-	CTransaction* secure = static_cast<CTransaction*>(Tx.get());
-	if (!m_ScriptDBTip->GetScript(boost::get<CRegID>(secure->desUserId), vScript)) {
-		LogPrint("ERROR", "Script is not Registed %s\r\n", boost::get<CRegID>(secure->desUserId).ToString());
-		return false;
-	}
+    CTransaction* secure = static_cast<CTransaction*>(Tx.get());
+    if (!m_ScriptDBTip->GetScript(boost::get<CRegID>(secure->desUserId), vScript)) {
+        LogPrint("ERROR", "Script is not Registed %s\r\n", boost::get<CRegID>(secure->desUserId).ToString());
+        return false;
+    }
 
-	CDataStream stream(vScript, SER_DISK, CLIENT_VERSION);
-	try {
-		stream >> vmScript;
-	} catch (exception& e) {
-		LogPrint("ERROR", "%s\r\n", "CVmScriptRun::intial() Unserialize to vmScript error");
-		throw runtime_error("CVmScriptRun::intial() Unserialize to vmScript error:" + string(e.what()));
-	}
+    CDataStream stream(vScript, SER_DISK, CLIENT_VERSION);
+    try {
+        stream >> vmScript;
+    } catch (exception& e) {
+        LogPrint("ERROR", "%s\n", "CVmScriptRun::intial() Unserialize to vmScript error");
+        throw runtime_error("CVmScriptRun::intial() Unserialize to vmScript error:" + string(e.what()));
+    }
 
-	if (vmScript.IsValid() == false){
-		LogPrint("ERROR", "%s\r\n", "CVmScriptRun::intial() vmScript.IsValid error");
-		return false;
-	}
-	isCheckAccount = vmScript.IsCheckAccount();
-	if(secure->vContract.size() >=4*1024 ){
-		LogPrint("ERROR", "%s\r\n", "CVmScriptRun::intial() vContract context size lager 4096");
-		return false;
-	}
+    if (vmScript.IsValid() == false){
+        LogPrint("ERROR", "%s\n", "CVmScriptRun::intial() vmScript.IsValid error");
+        return false;
+    }
+    isCheckAccount = vmScript.IsCheckAccount();
+    if(secure->vContract.size() >=4*1024 ){
+        LogPrint("ERROR", "%s\n", "CVmScriptRun::intial() vContract context size lager 4096");
+        return false;
+    }
 
-	try {
-		pLua = std::make_shared<CVmlua>(vmScript.Rom, secure->vContract);
-	} catch (exception& e) {
-		LogPrint("ERROR", "%s\r\n", "CVmScriptRun::intial() CVmlua init error");
-		return false;
-	}
+    try {
+        pLua = std::make_shared<CVmlua>(vmScript.Rom, secure->vContract);
+    } catch (exception& e) {
+        LogPrint("ERROR", "%s\n", "CVmScriptRun::intial() CVmlua init error");
+        return false;
+    }
 
-	//pVmRunEvn = this; //传CVmRunEvn对象指针给lmylib.cpp库使用
-	LogPrint("vm", "%s\r\n", "CVmScriptRun::intial() LUA");
+    //pVmRunEvn = this; //传CVmRunEvn对象指针给lmylib.cpp库使用
+    LogPrint("vm", "%s\n", "CVmScriptRun::intial() LUA");
 
-	return true;
+    return true;
 }
 
 CVmRunEvn::~CVmRunEvn() {
 
 }
 tuple<bool, uint64_t, string> CVmRunEvn::run(shared_ptr<CBaseTransaction>& Tx, CAccountViewCache& view, CScriptDBViewCache& VmDB, int nHeight,
-		uint64_t nBurnFactor, uint64_t &uRunStep) {
+        uint64_t nBurnFactor, uint64_t &uRunStep) {
 
-	if(nBurnFactor == 0)
-	{
-//		assert(0);
-		return std::make_tuple (false, 0, string("VmScript nBurnFactor == 0 \n"));
-	}
-	m_ScriptDBTip = &VmDB;
+    if(nBurnFactor == 0)
+    {
+//      assert(0);
+        return std::make_tuple (false, 0, string("VmScript nBurnFactor == 0 \n"));
+    }
+    m_ScriptDBTip = &VmDB;
 
-	CTransaction* tx = static_cast<CTransaction*>(Tx.get());
-	if(tx->llFees < CBaseTransaction::nMinTxFee) {
-		return std::make_tuple (false, 0, string("CVmRunEvn: Contract Tx fee too small\n"));
-	}
-	uint64_t maxstep = ((tx->llFees-CBaseTransaction::nMinTxFee)/ nBurnFactor) * 100;
-	
-	if(maxstep > MAX_BLOCK_RUN_STEP){
-		maxstep = MAX_BLOCK_RUN_STEP;
-	}
-	LogPrint("vm", "tx hash:%s fees=%lld fuelrate=%lld maxstep:%d\n", Tx->GetHash().GetHex(), tx->llFees, nBurnFactor, maxstep);
-	if (!intial(Tx, view, nHeight)) {
-		return std::make_tuple (false, 0, string("VmScript inital Failed\n"));
-	}
+    CTransaction* tx = static_cast<CTransaction*>(Tx.get());
+    if(tx->llFees < CBaseTransaction::nMinTxFee) {
+        return std::make_tuple (false, 0, string("CVmRunEvn: Contract Tx fee too small\n"));
+    }
+    uint64_t maxstep = ((tx->llFees-CBaseTransaction::nMinTxFee)/ nBurnFactor) * 100;
 
-	int64_t step = 0;
+    if(maxstep > MAX_BLOCK_RUN_STEP){
+        maxstep = MAX_BLOCK_RUN_STEP;
+    }
+    LogPrint("vm", "tx hash:%s fees=%lld fuelrate=%lld maxstep:%d\n", Tx->GetHash().GetHex(), tx->llFees, nBurnFactor, maxstep);
+    if (!intial(Tx, view, nHeight)) {
+        return std::make_tuple (false, 0, string("VmScript inital Failed\n"));
+    }
 
-	tuple<uint64_t, string> ret = pLua.get()->run(maxstep,this);
-	LogPrint("vm", "%s\r\n", "CVmScriptRun::run() LUA");
-	step = std::get<0>(ret);
-	if (0 == step) {
-		return std::make_tuple(false, 0, string("VmScript run Failed\n"));
-	} else if (-1 == step) {
-		return std::make_tuple(false, 0, std::get<1>(ret));
-	}else{
-		uRunStep = step;
-	}
+    int64_t step = 0;
 
-	LogPrint("vm", "tx:%s,step:%ld\n", tx->ToString(view), uRunStep);
+    tuple<uint64_t, string> ret = pLua.get()->run(maxstep,this);
+    LogPrint("vm", "%s\r\n", "CVmScriptRun::run() LUA");
+    step = std::get<0>(ret);
+    if (0 == step) {
+        return std::make_tuple(false, 0, string("VmScript run Failed\n"));
+    } else if (-1 == step) {
+        return std::make_tuple(false, 0, std::get<1>(ret));
+    }else{
+        uRunStep = step;
+    }
 
-	if (!CheckOperate(m_output)) {
-		return std::make_tuple (false, 0, string("VmScript CheckOperate Failed \n"));
-	}
+    LogPrint("vm", "tx:%s,step:%ld\n", tx->ToString(view), uRunStep);
 
-	if (!OpeatorAccount(m_output, view, nHeight)) {
-		return std::make_tuple (false, 0, string("VmScript OpeatorAccount Failed\n"));
-	}
+    if (!CheckOperate(m_output)) {
+        return std::make_tuple (false, 0, string("VmScript CheckOperate Failed \n"));
+    }
 
-	LogPrint("vm", "isCheckAccount:%d\n", isCheckAccount);
-	if(isCheckAccount) {
-		LogPrint("vm","isCheckAccount is true\n");
-		if(!CheckAppAcctOperate(tx))
-			return std::make_tuple (false, 0, string("VmScript CheckAppAcct Failed\n"));
-	}
+    if (!OpeatorAccount(m_output, view, nHeight)) {
+        return std::make_tuple (false, 0, string("VmScript OpeatorAccount Failed\n"));
+    }
 
-	if(!OpeatorAppAccount(MapAppOperate, *m_ScriptDBTip))
-	{
-		return std::make_tuple (false, 0, string("OpeatorApp Account Failed\n"));
-	}
+    LogPrint("vm", "isCheckAccount:%d\n", isCheckAccount);
+    if(isCheckAccount) {
+        LogPrint("vm","isCheckAccount is true\n");
+        if(!CheckAppAcctOperate(tx))
+            return std::make_tuple (false, 0, string("VmScript CheckAppAcct Failed\n"));
+    }
 
-	if(SysCfg().GetOutPutLog() && m_output.size() > 0) {
-		CScriptDBOperLog operlog;
-		uint256 txhash = GetCurTxHash();
-		if(!m_ScriptDBTip->WriteTxOutPut(txhash, m_output, operlog))
-			return std::make_tuple (false, 0, string("write tx out put Failed \n"));
-		m_dblog->push_back(operlog);
-	}
+    if(!OpeatorAppAccount(MapAppOperate, *m_ScriptDBTip))
+    {
+        return std::make_tuple (false, 0, string("OpeatorApp Account Failed\n"));
+    }
+
+    if(SysCfg().GetOutPutLog() && m_output.size() > 0) {
+        CScriptDBOperLog operlog;
+        uint256 txhash = GetCurTxHash();
+        if(!m_ScriptDBTip->WriteTxOutPut(txhash, m_output, operlog))
+            return std::make_tuple (false, 0, string("write tx out put Failed \n"));
+        m_dblog->push_back(operlog);
+    }
 /*
-	uint64_t spend = uRunStep * nBurnFactor;
-		if((spend < uRunStep) || (spend < nBurnFactor)){
-		return std::make_tuple (false, 0, string("mul error\n"));
-	}
+    uint64_t spend = uRunStep * nBurnFactor;
+        if((spend < uRunStep) || (spend < nBurnFactor)){
+        return std::make_tuple (false, 0, string("mul error\n"));
+    }
 */
-	uint64_t spend = 0;
-	if(!SafeMultiply(uRunStep, nBurnFactor, spend))
-	{
-		return std::make_tuple (false, 0, string("mul error\n"));
-	}
-	return std::make_tuple (true, spend, string("VmScript Sucess\n"));
+    uint64_t spend = 0;
+    if(!SafeMultiply(uRunStep, nBurnFactor, spend))
+    {
+        return std::make_tuple (false, 0, string("mul error\n"));
+    }
+    return std::make_tuple (true, spend, string("VmScript Sucess\n"));
 
 }
 
 shared_ptr<CAccount> CVmRunEvn::GetNewAccount(shared_ptr<CAccount>& vOldAccount) {
-	if (NewAccont.size() == 0)
-		return NULL;
-	vector<shared_ptr<CAccount> >::iterator Iter;
-	for (Iter = NewAccont.begin(); Iter != NewAccont.end(); Iter++) {
-		shared_ptr<CAccount> temp = *Iter;
-		if (temp.get()->keyID == vOldAccount.get()->keyID) {
-			NewAccont.erase(Iter);
-			return temp;
-		}
-	}
-	return NULL;
+    if (NewAccont.size() == 0)
+        return NULL;
+    vector<shared_ptr<CAccount> >::iterator Iter;
+    for (Iter = NewAccont.begin(); Iter != NewAccont.end(); Iter++) {
+        shared_ptr<CAccount> temp = *Iter;
+        if (temp.get()->keyID == vOldAccount.get()->keyID) {
+            NewAccont.erase(Iter);
+            return temp;
+        }
+    }
+    return NULL;
 }
 shared_ptr<CAccount> CVmRunEvn::GetAccount(shared_ptr<CAccount>& Account) {
-	if (RawAccont.size() == 0)
-		return NULL;
-	vector<shared_ptr<CAccount> >::iterator Iter;
-	for (Iter = RawAccont.begin(); Iter != RawAccont.end(); Iter++) {
-		shared_ptr<CAccount> temp = *Iter;
-		if (Account.get()->keyID == temp.get()->keyID) {
-			return temp;
-		}
-	}
-	return NULL;
+    if (RawAccont.size() == 0)
+        return NULL;
+    vector<shared_ptr<CAccount> >::iterator Iter;
+    for (Iter = RawAccont.begin(); Iter != RawAccont.end(); Iter++) {
+        shared_ptr<CAccount> temp = *Iter;
+        if (Account.get()->keyID == temp.get()->keyID) {
+            return temp;
+        }
+    }
+    return NULL;
 }
 vector_unsigned_char CVmRunEvn::GetAccountID(CVmOperate value) {
-	vector_unsigned_char accountid;
-	if (value.nacctype == regid) {
-		accountid.assign(value.accountid, value.accountid + 6);
-	} else if (value.nacctype == base58addr) {
-		string addr(value.accountid,value.accountid+sizeof(value.accountid));
-		CKeyID KeyId = CKeyID(addr);
-		CRegID regid;
-		if(m_view->GetRegId(CUserID(KeyId), regid)){
-			accountid.assign(regid.GetVec6().begin(),regid.GetVec6().end());
-		}else{
-			accountid.assign(value.accountid, value.accountid + 34);
-		}
-	}
-	return accountid;
+    vector_unsigned_char accountid;
+    if (value.nacctype == regid) {
+        accountid.assign(value.accountid, value.accountid + 6);
+    } else if (value.nacctype == base58addr) {
+        string addr(value.accountid,value.accountid+sizeof(value.accountid));
+        CKeyID KeyId = CKeyID(addr);
+        CRegID regid;
+        if(m_view->GetRegId(CUserID(KeyId), regid)){
+            accountid.assign(regid.GetVec6().begin(),regid.GetVec6().end());
+        }else{
+            accountid.assign(value.accountid, value.accountid + 34);
+        }
+    }
+    return accountid;
 }
 
 shared_ptr<CAppUserAccout> CVmRunEvn::GetAppAccount(shared_ptr<CAppUserAccout>& AppAccount) {
-	if (RawAppUserAccout.size() == 0)
-		return NULL;
-	vector<shared_ptr<CAppUserAccout> >::iterator Iter;
-	for (Iter = RawAppUserAccout.begin(); Iter != RawAppUserAccout.end(); Iter++) {
-		shared_ptr<CAppUserAccout> temp = *Iter;
-		if (AppAccount.get()->getaccUserId() == temp.get()->getaccUserId()) {
-			return temp;
-		}
-	}
-	return NULL;
+    if (RawAppUserAccout.size() == 0)
+        return NULL;
+    vector<shared_ptr<CAppUserAccout> >::iterator Iter;
+    for (Iter = RawAppUserAccout.begin(); Iter != RawAppUserAccout.end(); Iter++) {
+        shared_ptr<CAppUserAccout> temp = *Iter;
+        if (AppAccount.get()->getaccUserId() == temp.get()->getaccUserId()) {
+            return temp;
+        }
+    }
+    return NULL;
 }
 
 bool CVmRunEvn::CheckOperate(const vector<CVmOperate> &listoperate) {
-	// judge contract rulue
-	uint64_t addmoey = 0, miusmoney = 0;
-	uint64_t operValue = 0;
-	if(listoperate.size() > MAX_OUTPUT_COUNT) {
-		return false;
-	}
+    // judge contract rulue
+    uint64_t addmoey = 0, miusmoney = 0;
+    uint64_t operValue = 0;
+    if(listoperate.size() > MAX_OUTPUT_COUNT) {
+        return false;
+    }
 
-	for (auto& it : listoperate) {
+    for (auto& it : listoperate) {
 
-		if(it.nacctype != regid && it.nacctype != base58addr)
-			return false;
+        if(it.nacctype != regid && it.nacctype != base58addr)
+            return false;
 
-		if (it.opeatortype == ADD_FREE ) {
-			memcpy(&operValue,it.money,sizeof(it.money));
-			/*
-			uint64_t temp = addmoey;
-			temp += operValue;
-			if(temp < operValue || temp<addmoey) {
-				return false;
-			}
-			*/
-			uint64_t temp = 0;
-			if(!SafeAdd(addmoey, operValue, temp)) {
-				return false;
-			}
-			addmoey = temp;
-		}else if (it.opeatortype == MINUS_FREE) {
+        if (it.opeatortype == ADD_FREE ) {
+            memcpy(&operValue,it.money,sizeof(it.money));
+            /*
+            uint64_t temp = addmoey;
+            temp += operValue;
+            if(temp < operValue || temp<addmoey) {
+                return false;
+            }
+            */
+            uint64_t temp = 0;
+            if(!SafeAdd(addmoey, operValue, temp)) {
+                return false;
+            }
+            addmoey = temp;
+        }else if (it.opeatortype == MINUS_FREE) {
 
-			//vector<unsigned char > accountid(it.accountid,it.accountid+sizeof(it.accountid));
-			vector_unsigned_char accountid = GetAccountID(it);
-			if(accountid.size() != 6)
-				return false;
-			CRegID regId(accountid);
-			CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-			/// current tx's script cant't mius other script's regid
-			if(m_ScriptDBTip->HaveScript(regId) && regId != boost::get<CRegID>(tx->desUserId))
-			{
-				return false;
-			}
+            //vector<unsigned char > accountid(it.accountid,it.accountid+sizeof(it.accountid));
+            vector_unsigned_char accountid = GetAccountID(it);
+            if(accountid.size() != 6)
+                return false;
+            CRegID regId(accountid);
+            CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+            /// current tx's script cant't mius other script's regid
+            if(m_ScriptDBTip->HaveScript(regId) && regId != boost::get<CRegID>(tx->desUserId))
+            {
+                return false;
+            }
 
-			memcpy(&operValue,it.money,sizeof(it.money));
-			/*
-			uint64_t temp = miusmoney;
-			temp += operValue;
-			if(temp < operValue || temp < miusmoney) {
-				return false;
-			}
-			*/
-			uint64_t temp = 0;
-			if(!SafeAdd(miusmoney, operValue, temp)) {
-				return false;
-			}
-			miusmoney = temp;
-		}
-		else{
-//			Assert(0);
-			return false; // 输入数据错误
-		}
+            memcpy(&operValue,it.money,sizeof(it.money));
+            /*
+            uint64_t temp = miusmoney;
+            temp += operValue;
+            if(temp < operValue || temp < miusmoney) {
+                return false;
+            }
+            */
+            uint64_t temp = 0;
+            if(!SafeAdd(miusmoney, operValue, temp)) {
+                return false;
+            }
+            miusmoney = temp;
+        }
+        else{
+//          Assert(0);
+            return false; // 输入数据错误
+        }
 
-		//vector<unsigned char> accountid(it.accountid, it.accountid + sizeof(it.accountid));
-		vector_unsigned_char accountid = GetAccountID(it);
-		if(accountid.size() == 6){
-			CRegID regId(accountid);
-			if(regId.IsEmpty() || regId.getKeyID( *m_view) == uint160())
-				return false;
-			//  app only be allowed minus self money
-			if (!m_ScriptDBTip->HaveScript(regId) && it.opeatortype == MINUS_FREE) {
-				return false;
-			}
-		}
+        //vector<unsigned char> accountid(it.accountid, it.accountid + sizeof(it.accountid));
+        vector_unsigned_char accountid = GetAccountID(it);
+        if(accountid.size() == 6){
+            CRegID regId(accountid);
+            if(regId.IsEmpty() || regId.getKeyID( *m_view) == uint160())
+                return false;
+            //  app only be allowed minus self money
+            if (!m_ScriptDBTip->HaveScript(regId) && it.opeatortype == MINUS_FREE) {
+                return false;
+            }
+        }
 
-	}
-	if (addmoey != miusmoney)
-	{
-		return false;
-	}
-	return true;
+    }
+    if (addmoey != miusmoney)
+    {
+        return false;
+    }
+    return true;
 }
 
 bool CVmRunEvn::CheckAppAcctOperate(CTransaction* tx) {
-	int64_t addValue(0), minusValue(0), sumValue(0);
-	for(auto  vOpItem : MapAppOperate) {
-		for(auto appFund : vOpItem.second) {
-			if(ADD_FREE_OP == appFund.opeatortype || ADD_TAG_OP == appFund.opeatortype) {
-				/*
-				int64_t temp = appFund.mMoney;
-				temp += addValue;
-				if(temp < addValue || temp<appFund.mMoney) {
-					return false;
-				}
-				*/
-				int64_t temp = 0;
-				if(!SafeAdd(appFund.mMoney, addValue, temp)) {
-					return false;
-				}
-				addValue = temp;
-			}
-			else if(SUB_FREE_OP == appFund.opeatortype || SUB_TAG_OP == appFund.opeatortype) {
-				/*
-				int64_t temp = appFund.mMoney;
-				temp += minusValue;
-				if(temp < minusValue || temp<appFund.mMoney) {
-					return false;
-				}
-				*/
-				int64_t temp = 0;
-				if(!SafeAdd(appFund.mMoney, minusValue, temp)) {
-					return false;
-				}
-				minusValue = temp;
-			}
-		}
-	}
-	/*
-	sumValue = addValue - minusValue;
-	if(sumValue > addValue) {
-		return false;
-	}
-	*/
-	if(!SafeSubtract(addValue, minusValue, sumValue)) {
-		return false;
-	}
+    int64_t addValue(0), minusValue(0), sumValue(0);
+    for(auto  vOpItem : MapAppOperate) {
+        for(auto appFund : vOpItem.second) {
+            if(ADD_FREE_OP == appFund.opeatortype || ADD_TAG_OP == appFund.opeatortype) {
+                /*
+                int64_t temp = appFund.mMoney;
+                temp += addValue;
+                if(temp < addValue || temp<appFund.mMoney) {
+                    return false;
+                }
+                */
+                int64_t temp = 0;
+                if(!SafeAdd(appFund.mMoney, addValue, temp)) {
+                    return false;
+                }
+                addValue = temp;
+            }
+            else if(SUB_FREE_OP == appFund.opeatortype || SUB_TAG_OP == appFund.opeatortype) {
+                /*
+                int64_t temp = appFund.mMoney;
+                temp += minusValue;
+                if(temp < minusValue || temp<appFund.mMoney) {
+                    return false;
+                }
+                */
+                int64_t temp = 0;
+                if(!SafeAdd(appFund.mMoney, minusValue, temp)) {
+                    return false;
+                }
+                minusValue = temp;
+            }
+        }
+    }
+    /*
+    sumValue = addValue - minusValue;
+    if(sumValue > addValue) {
+        return false;
+    }
+    */
+    if(!SafeSubtract(addValue, minusValue, sumValue)) {
+        return false;
+    }
 
-	uint64_t sysContractAcct(0);
-	for(auto item : m_output) {
-		vector_unsigned_char vAccountId = GetAccountID(item);
-		if(vAccountId == boost::get<CRegID>(tx->desUserId).GetVec6() && item.opeatortype == MINUS_FREE) {
-			uint64_t value;
-			memcpy(&value, item.money, sizeof(item.money));
-			int64_t temp = value;
-			if(temp < 0) {
-				return false;
-			}
-			/*
-			temp += sysContractAcct;
-			if(temp < sysContractAcct || temp < (int64_t)value)
-				return false;
-			*/
-			uint64_t tempValue = temp;
-			uint64_t tempOut = 0;
-			if(!SafeAdd(tempValue, sysContractAcct, tempOut)) {
-				return false;
-			}
-			sysContractAcct = tempOut;
-		}
-	}
+    uint64_t sysContractAcct(0);
+    for(auto item : m_output) {
+        vector_unsigned_char vAccountId = GetAccountID(item);
+        if(vAccountId == boost::get<CRegID>(tx->desUserId).GetVec6() && item.opeatortype == MINUS_FREE) {
+            uint64_t value;
+            memcpy(&value, item.money, sizeof(item.money));
+            int64_t temp = value;
+            if(temp < 0) {
+                return false;
+            }
+            /*
+            temp += sysContractAcct;
+            if(temp < sysContractAcct || temp < (int64_t)value)
+                return false;
+            */
+            uint64_t tempValue = temp;
+            uint64_t tempOut = 0;
+            if(!SafeAdd(tempValue, sysContractAcct, tempOut)) {
+                return false;
+            }
+            sysContractAcct = tempOut;
+        }
+    }
 /*
-	int64_t sysAcctSum = tx->llValues - sysContractAcct;
-	if(sysAcctSum > (int64_t)tx->llValues) {
-		return false;
-	}
+    int64_t sysAcctSum = tx->llValues - sysContractAcct;
+    if(sysAcctSum > (int64_t)tx->llValues) {
+        return false;
+    }
 */
-	int64_t sysAcctSum = 0;
-	if (!SafeSubtract((int64_t)tx->llValues, (int64_t)sysContractAcct, sysAcctSum)) {
-		return false;
-	}
+    int64_t sysAcctSum = 0;
+    if (!SafeSubtract((int64_t)tx->llValues, (int64_t)sysContractAcct, sysAcctSum)) {
+        return false;
+    }
 
-	if(sumValue != sysAcctSum){
-		LogPrint("vm", "CheckAppAcctOperate:addValue=%lld, minusValue=%lld, txValue=%lld, sysContractAcct=%lld sumValue=%lld, sysAcctSum=%lld\n", addValue, minusValue, tx->llValues, sysContractAcct,sumValue, sysAcctSum);
-		return false;
-	}
-	return true;
+    if(sumValue != sysAcctSum){
+        LogPrint("vm", "CheckAppAcctOperate:addValue=%lld, minusValue=%lld, txValue=%lld, sysContractAcct=%lld sumValue=%lld, sysAcctSum=%lld\n", addValue, minusValue, tx->llValues, sysContractAcct,sumValue, sysAcctSum);
+        return false;
+    }
+    return true;
 }
 
 //shared_ptr<vector<CVmOperate>> CVmRunEvn::GetOperate() const {
-//	auto tem = std::make_shared<vector<CVmOperate>>();
-//	shared_ptr<vector<unsigned char>> retData = pMcu.get()->GetRetData();
-//	CDataStream Contractstream(*retData.get(), SER_DISK, CLIENT_VERSION);
-//	vector<CVmOperate> retvmcode;
-//	;
-//	Contractstream >> retvmcode;
-//	return tem;
+//  auto tem = std::make_shared<vector<CVmOperate>>();
+//  shared_ptr<vector<unsigned char>> retData = pMcu.get()->GetRetData();
+//  CDataStream Contractstream(*retData.get(), SER_DISK, CLIENT_VERSION);
+//  vector<CVmOperate> retvmcode;
+//  ;
+//  Contractstream >> retvmcode;
+//  return tem;
 //}
 
 bool CVmRunEvn::OpeatorAccount(const vector<CVmOperate>& listoperate, CAccountViewCache& view, const int nCurHeight) {
 
-	NewAccont.clear();
-	for (auto& it : listoperate) {
-//		CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-//		CFund fund;
-//		memcpy(&fund.value,it.money,sizeof(it.money));
-//		fund.nHeight = it.outheight;
-		uint64_t value;
-		memcpy(&value, it.money, sizeof(it.money));
+    NewAccont.clear();
+    for (auto& it : listoperate) {
+//      CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+//      CFund fund;
+//      memcpy(&fund.value,it.money,sizeof(it.money));
+//      fund.nHeight = it.outheight;
+        uint64_t value;
+        memcpy(&value, it.money, sizeof(it.money));
 
-		auto tem = std::make_shared<CAccount>();
-//		vector_unsigned_char accountid = GetAccountID(it);
-//		if (accountid.size() == 0) {
-//			return false;
-//		}
-//		vector_unsigned_char accountid(it.accountid,it.accountid+sizeof(it.accountid));
-		vector_unsigned_char accountid = GetAccountID(it);
-		CRegID userregId;
-		CKeyID userkeyid;
+        auto tem = std::make_shared<CAccount>();
+//      vector_unsigned_char accountid = GetAccountID(it);
+//      if (accountid.size() == 0) {
+//          return false;
+//      }
+//      vector_unsigned_char accountid(it.accountid,it.accountid+sizeof(it.accountid));
+        vector_unsigned_char accountid = GetAccountID(it);
+        CRegID userregId;
+        CKeyID userkeyid;
 
-		if(accountid.size() == 6){
-			userregId.SetRegID(accountid);
-			if(!view.GetAccount(CUserID(userregId), *tem.get())){
-				return false;                                           /// 账户不存在
-			}
-		}else{
-			string popaddr(accountid.begin(), accountid.end());
-			userkeyid = CKeyID(popaddr);
-			 if(!view.GetAccount(CUserID(userkeyid), *tem.get()))
-			 {
-				 tem->keyID = userkeyid;
-				//return false;                                           /// 未产生过交易记录的账户
-			 }
-		}
+        if(accountid.size() == 6){
+            userregId.SetRegID(accountid);
+            if(!view.GetAccount(CUserID(userregId), *tem.get())){
+                return false;                                           /// 账户不存在
+            }
+        }else{
+            string popaddr(accountid.begin(), accountid.end());
+            userkeyid = CKeyID(popaddr);
+             if(!view.GetAccount(CUserID(userkeyid), *tem.get()))
+             {
+                 tem->keyID = userkeyid;
+                //return false;                                           /// 未产生过交易记录的账户
+             }
+        }
 
-		shared_ptr<CAccount> vmAccount = GetAccount(tem);
-		if (vmAccount.get() == NULL) {
-			RawAccont.push_back(tem);
-			vmAccount = tem;
-		}
-		LogPrint("vm", "account id:%s\r\n", HexStr(accountid).c_str());
-		LogPrint("vm", "befer account:%s\r\n", vmAccount.get()->ToString().c_str());
-		bool ret = false;
-//		vector<CScriptDBOperLog> vAuthorLog;
-		//todolist
-//		if(IsSignatureAccount(vmAccount.get()->regID) || vmAccount.get()->regID == boost::get<CRegID>(tx->appRegId))
-		{
-			ret = vmAccount.get()->OperateAccount((OperType)it.opeatortype, value, nCurHeight);
-		}
-//		else{
-//			ret = vmAccount.get()->OperateAccount((OperType)it.opeatortype, fund, *m_ScriptDBTip, vAuthorLog,  height, &GetScriptRegID().GetVec6(), true);
-//		}
+        shared_ptr<CAccount> vmAccount = GetAccount(tem);
+        if (vmAccount.get() == NULL) {
+            RawAccont.push_back(tem);
+            vmAccount = tem;
+        }
+        LogPrint("vm", "account id:%s\r\n", HexStr(accountid).c_str());
+        LogPrint("vm", "befer account:%s\r\n", vmAccount.get()->ToString().c_str());
+        bool ret = false;
+//      vector<CScriptDBOperLog> vAuthorLog;
+        //todolist
+//      if(IsSignatureAccount(vmAccount.get()->regID) || vmAccount.get()->regID == boost::get<CRegID>(tx->appRegId))
+        {
+            ret = vmAccount.get()->OperateAccount((OperType)it.opeatortype, value, nCurHeight);
+        }
+//      else{
+//          ret = vmAccount.get()->OperateAccount((OperType)it.opeatortype, fund, *m_ScriptDBTip, vAuthorLog,  height, &GetScriptRegID().GetVec6(), true);
+//      }
 
-//		LogPrint("vm", "after account:%s\r\n", vmAccount.get()->ToString().c_str());
-		if (!ret) {
-			return false;
-		}
-		NewAccont.push_back(vmAccount);
-//		m_dblog->insert(m_dblog->end(), vAuthorLog.begin(), vAuthorLog.end());
+//      LogPrint("vm", "after account:%s\r\n", vmAccount.get()->ToString().c_str());
+        if (!ret) {
+            return false;
+        }
+        NewAccont.push_back(vmAccount);
+//      m_dblog->insert(m_dblog->end(), vAuthorLog.begin(), vAuthorLog.end());
 
-	}
-	return true;
+    }
+    return true;
 }
 
 const CRegID& CVmRunEvn::GetScriptRegID()
 {   // 获取目的账户ID
-	CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-	return boost::get<CRegID>(tx->desUserId);
+    CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+    return boost::get<CRegID>(tx->desUserId);
 }
 
 const CRegID &CVmRunEvn::GetTxAccount() {
-	CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-	return boost::get<CRegID>(tx->srcRegId);
+    CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+    return boost::get<CRegID>(tx->srcRegId);
 }
 uint64_t CVmRunEvn::GetValue() const{
-	CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-		return tx->llValues;
+    CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+        return tx->llValues;
 }
 const vector<unsigned char>& CVmRunEvn::GetTxContact()
 {
-	CTransaction* tx = static_cast<CTransaction*>(listTx.get());
-		return tx->vContract;
+    CTransaction* tx = static_cast<CTransaction*>(listTx.get());
+        return tx->vContract;
 }
 int CVmRunEvn::GetComfirHeight()
 {
-	return RunTimeHeight;
+    return RunTimeHeight;
 }
 uint256 CVmRunEvn::GetCurTxHash()
 {
-	return listTx.get()->GetHash();
+    return listTx.get()->GetHash();
 }
 CScriptDBViewCache* CVmRunEvn::GetScriptDB()
 {
-	return m_ScriptDBTip;
+    return m_ScriptDBTip;
 }
 CAccountViewCache * CVmRunEvn::GetCatchView()
 {
-	return m_view;
+    return m_view;
 }
 void CVmRunEvn::InsertOutAPPOperte(const vector<unsigned char>& userId,const CAppFundOperate &source)
 {
-	if(MapAppOperate.count(userId))
-	{
-		MapAppOperate[userId].push_back(source);
-	}
-	else
-	{
-		vector<CAppFundOperate> it;
-		it.push_back(source);
-		MapAppOperate[userId] = it;
-	}
+    if(MapAppOperate.count(userId))
+    {
+        MapAppOperate[userId].push_back(source);
+    }
+    else
+    {
+        vector<CAppFundOperate> it;
+        it.push_back(source);
+        MapAppOperate[userId] = it;
+    }
 
 }
 bool CVmRunEvn::InsertOutputData(const vector<CVmOperate>& source)
 {
-	m_output.insert(m_output.end(),source.begin(),source.end());
-	if(m_output.size() < MAX_OUTPUT_COUNT)
-		return true;
-	return false;
+    m_output.insert(m_output.end(),source.begin(),source.end());
+    if(m_output.size() < MAX_OUTPUT_COUNT)
+        return true;
+    return false;
 }
 shared_ptr<vector<CScriptDBOperLog> > CVmRunEvn::GetDbLog()
 {
-	return m_dblog;
+    return m_dblog;
 }
 
 /**
@@ -540,87 +540,87 @@ shared_ptr<vector<CScriptDBOperLog> > CVmRunEvn::GetDbLog()
  * @return
  */
 bool CVmRunEvn::GetAppUserAccout(const vector<unsigned char> &vAppUserId, shared_ptr<CAppUserAccout> &sptrAcc) {
-	assert(m_ScriptDBTip != NULL);
-	shared_ptr<CAppUserAccout> tem = std::make_shared<CAppUserAccout>();
-	if (!m_ScriptDBTip->GetScriptAcc(GetScriptRegID(), vAppUserId, *tem.get())) {
-			tem = std::make_shared<CAppUserAccout>(vAppUserId);
-			sptrAcc = tem;
-			return true;
-	}
-	if (!tem.get()->AutoMergeFreezeToFree(RunTimeHeight)) {
-		return false;
-	}
-	sptrAcc = tem;
-	return true;
+    assert(m_ScriptDBTip != NULL);
+    shared_ptr<CAppUserAccout> tem = std::make_shared<CAppUserAccout>();
+    if (!m_ScriptDBTip->GetScriptAcc(GetScriptRegID(), vAppUserId, *tem.get())) {
+            tem = std::make_shared<CAppUserAccout>(vAppUserId);
+            sptrAcc = tem;
+            return true;
+    }
+    if (!tem.get()->AutoMergeFreezeToFree(RunTimeHeight)) {
+        return false;
+    }
+    sptrAcc = tem;
+    return true;
 }
 
 bool CVmRunEvn::OpeatorAppAccount(const map<vector<unsigned char >,vector<CAppFundOperate> > opMap, CScriptDBViewCache& view) {
-	NewAppUserAccout.clear();
-	if ((MapAppOperate.size() > 0)) {
-		for (auto const tem : opMap) {
-			shared_ptr<CAppUserAccout> sptrAcc;
-			if (!GetAppUserAccout(tem.first, sptrAcc)) {
-				LogPrint("vm", "GetAppUserAccout(tem.first, sptrAcc, true) failed \r\n appuserid :%s\r\n",
-						HexStr(tem.first));
-				return false;
-			}
-			if (!sptrAcc.get()->AutoMergeFreezeToFree(RunTimeHeight)) {
-				LogPrint("vm", "AutoMergeFreezeToFreefailed \r\n appuser :%s\r\n", sptrAcc.get()->toString());
-				return false;
+    NewAppUserAccout.clear();
+    if ((MapAppOperate.size() > 0)) {
+        for (auto const tem : opMap) {
+            shared_ptr<CAppUserAccout> sptrAcc;
+            if (!GetAppUserAccout(tem.first, sptrAcc)) {
+                LogPrint("vm", "GetAppUserAccout(tem.first, sptrAcc, true) failed \r\n appuserid :%s\r\n",
+                        HexStr(tem.first));
+                return false;
+            }
+            if (!sptrAcc.get()->AutoMergeFreezeToFree(RunTimeHeight)) {
+                LogPrint("vm", "AutoMergeFreezeToFreefailed \r\n appuser :%s\r\n", sptrAcc.get()->toString());
+                return false;
 
-			}
-			shared_ptr<CAppUserAccout> vmAppAccount = GetAppAccount(sptrAcc);
-			if (vmAppAccount.get() == NULL) {
-				RawAppUserAccout.push_back(sptrAcc);
-				vmAppAccount = sptrAcc;
-			}
-			LogPrint("vm", "before user: %s\r\n", sptrAcc.get()->toString());
-			if (!sptrAcc.get()->Operate(tem.second)) {
+            }
+            shared_ptr<CAppUserAccout> vmAppAccount = GetAppAccount(sptrAcc);
+            if (vmAppAccount.get() == NULL) {
+                RawAppUserAccout.push_back(sptrAcc);
+                vmAppAccount = sptrAcc;
+            }
+            LogPrint("vm", "before user: %s\r\n", sptrAcc.get()->toString());
+            if (!sptrAcc.get()->Operate(tem.second)) {
 
-				int i = 0;
-				for (auto const pint : tem.second) {
-					LogPrint("vm", "GOperate failed \r\n Operate %d : %s\r\n", i++, pint.toString());
-				}
-				LogPrint("vm", "GetAppUserAccout(tem.first, sptrAcc, true) failed \r\n appuserid :%s\r\n",
-						HexStr(tem.first));
-				return false;
-			}
-			NewAppUserAccout.push_back(sptrAcc);
-			LogPrint("vm", "after user: %s\r\n", sptrAcc.get()->toString());
-			CScriptDBOperLog log;
-			view.SetScriptAcc(GetScriptRegID(), *sptrAcc.get(), log);
-			shared_ptr<vector<CScriptDBOperLog> > m_dblog = GetDbLog();
-			m_dblog.get()->push_back(log);
+                int i = 0;
+                for (auto const pint : tem.second) {
+                    LogPrint("vm", "GOperate failed \r\n Operate %d : %s\r\n", i++, pint.toString());
+                }
+                LogPrint("vm", "GetAppUserAccout(tem.first, sptrAcc, true) failed \r\n appuserid :%s\r\n",
+                        HexStr(tem.first));
+                return false;
+            }
+            NewAppUserAccout.push_back(sptrAcc);
+            LogPrint("vm", "after user: %s\r\n", sptrAcc.get()->toString());
+            CScriptDBOperLog log;
+            view.SetScriptAcc(GetScriptRegID(), *sptrAcc.get(), log);
+            shared_ptr<vector<CScriptDBOperLog> > m_dblog = GetDbLog();
+            m_dblog.get()->push_back(log);
 
-		}
-	}
-	return true;
+        }
+    }
+    return true;
 }
 
 void CVmRunEvn::SetCheckAccount(bool bCheckAccount)
 {
-	isCheckAccount = bCheckAccount;
+    isCheckAccount = bCheckAccount;
 }
 
 Object CVmOperate::ToJson() {
-	Object obj;
-	if(nacctype == regid) {
-		vector<unsigned char> vRegId(accountid, accountid+6);
-		CRegID regId(vRegId);
-		obj.push_back(Pair("regid", regId.ToString()));
-	}else if(nacctype == base58addr) {
-		string addr(accountid,accountid+sizeof(accountid));
-		obj.push_back(Pair("addr", addr));
-	}
-	if(opeatortype == ADD_FREE) {
-		obj.push_back(Pair("opertype", "add"));
-	}else if(opeatortype == MINUS_FREE) {
-		obj.push_back(Pair("opertype", "minus"));
-	}
-	if(outheight > 0)
-		obj.push_back(Pair("freezeheight", (int) outheight));
-	uint64_t amount;
-	memcpy(&amount, money, sizeof(money));
-	obj.push_back(Pair("amount", amount));
-	return obj;
+    Object obj;
+    if(nacctype == regid) {
+        vector<unsigned char> vRegId(accountid, accountid+6);
+        CRegID regId(vRegId);
+        obj.push_back(Pair("regid", regId.ToString()));
+    }else if(nacctype == base58addr) {
+        string addr(accountid,accountid+sizeof(accountid));
+        obj.push_back(Pair("addr", addr));
+    }
+    if(opeatortype == ADD_FREE) {
+        obj.push_back(Pair("opertype", "add"));
+    }else if(opeatortype == MINUS_FREE) {
+        obj.push_back(Pair("opertype", "minus"));
+    }
+    if(outheight > 0)
+        obj.push_back(Pair("freezeheight", (int) outheight));
+    uint64_t amount;
+    memcpy(&amount, money, sizeof(money));
+    obj.push_back(Pair("amount", amount));
+    return obj;
 }


### PR DESCRIPTION
**Changes**
1. rename GetTxAccounts to GetTxRegID
2. convert tabs to spaces
3. handle exception in ExGetTxRegID(), which returns a RegID related to a COMMON_TX or CONTRACT_TX transaction. If the transaction's type is neither COMMON_TX nor CONTRACT_TX, returns a null result with error message like this: ExGetTxRegID, tx typeerror