### PR TITLE
avoid ambiguity in invalidateblock rpc

### DIFF
--- a/docs/CmdHelp.md
+++ b/docs/CmdHelp.md
@@ -42,7 +42,7 @@
 | help | ```[command]``` | List commands, or get help for a command | N |
 | importprivkey | ```<wiccprivkey> [label] [rescan=true]``` | Adds a private key (as returned by dumpprivkey) to your wallet. This may take a while, as a rescan is done, looking for existing transactions. Note: There's no need to import public key, as in ECDSA (unlike RSA), which can be computed from private key. | Y |
 | importwallet | ```<filename>``` | Import keys from a wallet dump file (see dumpwallet). | Y |
-| invalidateblock | ```<hash or height>``` | Mark a block as invalid. | N |
+| invalidateblock | ```<hash>``` | Mark a block as invalid. | N |
 | islocked | | Return an object about whether the wallet is being locked or unlocked | N |
 | listaddr | | return Array containing address,balance,haveminerkey,regid information | N |
 | listapp | ```<showDetail>``` | get the list register script: <br>1. showDetail  (boolean, required)true to show scriptContent,otherwise to not show it. | N |

--- a/src/rpc/rpcblockchain.cpp
+++ b/src/rpc/rpcblockchain.cpp
@@ -447,27 +447,16 @@ Value listcheckpoint(const Array& params, bool fHelp)
 Value invalidateblock(const Array& params, bool fHelp) {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "invalidateblock \"hash or height\"\n"
+            "invalidateblock \"hash\"\n"
             "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n"
             "\nArguments:\n"
-            "1. \"hash or height\"(string or numeric, required) string for The block hash, numeric for the block height\n"
+            "1. hash   (string, required) the hash of the block to mark as invalid\n"
             "\nResult:\n"
             "\nExamples:\n"
-            + HelpExampleCli("invalidateblock", "\"hash or height\"")
-            + HelpExampleRpc("invalidateblock", "\"hash or height\""));
+            + HelpExampleCli("invalidateblock", "\"hash\"")
+            + HelpExampleRpc("invalidateblock", "\"hash\""));
 
-    std::string strHash;
-    if (int_type == params[0].type()) {
-        int nHeight = params[0].get_int();
-        if (nHeight < 0 || nHeight > chainActive.Height())
-            throw runtime_error("Block number out of range.");
-
-        CBlockIndex *pblockindex = chainActive[nHeight];
-        strHash = pblockindex->GetBlockHash().GetHex();
-    } else {
-        strHash = params[0].get_str();
-    }
-
+    std::string strHash = params[0].get_str();
     uint256 hash(uint256S(strHash));
     CValidationState state;
 

--- a/src/rpc/rpcblockchain.cpp
+++ b/src/rpc/rpcblockchain.cpp
@@ -450,7 +450,7 @@ Value invalidateblock(const Array& params, bool fHelp) {
             "invalidateblock \"hash\"\n"
             "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n"
             "\nArguments:\n"
-            "1. hash   (string, required) the hash of the block to mark as invalid\n"
+            "1. \"hash\"         (string, required) the hash of the block to mark as invalid\n"
             "\nResult:\n"
             "\nExamples:\n"
             + HelpExampleCli("invalidateblock", "\"hash\"")

--- a/src/rpc/rpcclient.cpp
+++ b/src/rpc/rpcclient.cpp
@@ -251,8 +251,6 @@ Array RPCConvertValues(const string &strMethod, const vector<string> &strParams)
     if (strMethod == "notionalpoolingasset"   && n > 2) ConvertTo<double>(params[2]);
     if (strMethod == "getdelegatelist"        && n > 0) ConvertTo<int>(params[0]);
 
-    if (strMethod == "invalidateblock"        && n > 0) { if (params[0].get_str().size() < 32) ConvertTo<int>(params[0]); }
-
     return params;
 }
 


### PR DESCRIPTION
When the blockchain is forking temporarily into two chains called `A` and `B`, it's ambiguous to call `invalidateblock` rpc with `height`, as the `height` could be refered to two block hashes in the different chains.

So, it's better to use a specfic block hash in `invalidateblock` rpc like this:

```code
root@ubuntu:~/WaykiChain/test/node1# ./node1 -datadir=. invalidateblock f4bb253c71c00c2323a0160f2c7b65af8f0ff64638105d48d33511f01d485089
{
    "msg" : "success"
}
```