### PR TITLE
fix: enable limit free relay

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -275,13 +275,7 @@ struct CDiskTxPos : public CDiskBlockPos
 
 
 
-enum GetMinFee_mode
-{
-    GMF_RELAY,
-    GMF_SEND,
-};
-
-int64_t GetMinFee(const CBaseTransaction *pBaseTx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode);
+int64_t GetMinRelayFee(const CBaseTransaction *pBaseTx, unsigned int nBytes, bool fAllowFree);
 
 
 /** Count ECDSA signature operations the old-fashioned (pre-0.6) way


### PR DESCRIPTION
If anyone try to broadcast too many free or very-low-fee transactions to the network, all the honest nodes would reject the transactions like this: `AcceptToMemoryPool : free transaction rejected by rate limiter` in `ERROR.log`

```code
if (dFreeCount >= SysCfg().GetArg("-limitfreerelay", 15)*10*1000/60)
    return state.DoS(0, ERRORMSG("AcceptToMemoryPool : free transaction rejected by rate limiter"),
                     REJECT_INSUFFICIENTFEE, "insufficient priority");
```