### PR TITLE
fix: call generatecoinblock failed in mainnet

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -244,7 +244,7 @@ bool GetCurrentDelegate(const int64_t currentTime,  const vector<CAccount> &vDel
     int64_t slot =  currentTime / SysCfg().GetTargetSpacing();
     int miner = slot % IniCfg().GetDelegatesCfg();
     delegateAcct = vDelegatesAcctList[miner];
-    LogPrint("MINER", "currentTime=%lld, slot=%d, miner=%d, minderAddr=%s\n",
+    LogPrint("DEBUG", "currentTime=%lld, slot=%d, miner=%d, minderAddr=%s\n",
         currentTime, slot, miner, delegateAcct.keyID.ToAddress());
     return true;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -651,7 +651,7 @@ void static CoinMiner(CWallet *pwallet, int targetHeight) {
 
     if (!CheckIsHaveMinerKey()) {
         LogPrint("INFO", "CoinMiner terminated.\n");
-        ERRORMSG("ERROR:%s ", "No key for mining\n");
+        ERRORMSG("No key for mining");
         return;
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -712,13 +712,14 @@ void GenerateCoinBlock(bool fGenerate, CWallet* pwallet, int targetHeight) {
         minerThreads = NULL;
     }
 
-    if (targetHeight <= 0 && fGenerate == true) {
-        ERRORMSG("targetHeight, fGenerate value error");
-        return ;
-    }
-
     if (!fGenerate)
         return;
+
+    // In mainnet, coin miner should generate blocks continuously regardless of target height.
+    if (SysCfg().NetworkID() != MAIN_NET && targetHeight <= 0) {
+        ERRORMSG("targetHeight, fGenerate value error");
+        return;
+    }
 
     minerThreads = new boost::thread_group();
     minerThreads->create_thread(boost::bind(&CoinMiner, pwallet, targetHeight));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -190,7 +190,7 @@ uint256 GetAdjustHash(const uint256 TargetHash, const uint64_t nPos, const int n
 
 bool GetDelegatesAcctList(vector<CAccount> &vDelegatesAcctList, CAccountViewCache &accViewIn, CTransactionDBCache &txCacheIn, CScriptDBViewCache &scriptCacheIn) {
     LOCK(cs_main);
-    CAccountViewCache accview(accViewIn, true);
+    CAccountViewCache accView(accViewIn, true);
     CTransactionDBCache txCache(txCacheIn, true);
     CScriptDBViewCache scriptCache(scriptCacheIn, true);
 
@@ -213,7 +213,7 @@ bool GetDelegatesAcctList(vector<CAccount> &vDelegatesAcctList, CAccountViewCach
             vector<unsigned char> vAcctRegId(iterVotes + SCRIPT_KEY_PREFIX_LENGTH + VOTES_STRING_SIZE + 1, vScriptKey.end());
             CRegID acctRegId(vAcctRegId);
             CAccount account;
-            if (!accview.GetAccount(acctRegId, account)) {
+            if (!accView.GetAccount(acctRegId, account)) {
                 LogPrint("ERROR", "GetAccount Error, acctRegId:%s\n", acctRegId.ToString());
                 //assert(0);
                 //StartShutdown();
@@ -244,7 +244,7 @@ bool GetCurrentDelegate(const int64_t currentTime,  const vector<CAccount> &vDel
     int64_t slot =  currentTime / SysCfg().GetTargetSpacing();
     int miner = slot % IniCfg().GetDelegatesCfg();
     delegateAcct = vDelegatesAcctList[miner];
-    LogPrint("DEBUG", "currentTime=%lld, slot=%d, miner=%d, minderAddr=%s\n",
+    LogPrint("MINER", "currentTime=%lld, slot=%d, miner=%d, minderAddr=%s\n",
         currentTime, slot, miner, delegateAcct.keyID.ToAddress());
     return true;
 }
@@ -309,9 +309,10 @@ void ShuffleDelegates(const int nCurHeight, vector<CAccount> &vDelegatesList) {
 
 }
 
-bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache, bool bNeedRunTx) {
+bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionDBCache &txCache,
+                 CScriptDBViewCache &scriptCache, bool bNeedRunTx) {
 
-    uint64_t maxNonce = SysCfg().GetBlockMaxNonce(); //cacul times
+    uint64_t maxNonce = SysCfg().GetBlockMaxNonce();
     vector<CAccount> vDelegatesAcctList;
 
     if (!GetDelegatesAcctList(vDelegatesAcctList, accView, txCache, scriptCache))
@@ -320,7 +321,7 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
     ShuffleDelegates(pBlock->GetHeight(), vDelegatesAcctList);
 
     CAccount curDelegate;
-    if(!GetCurrentDelegate(pBlock->GetTime(), vDelegatesAcctList, curDelegate)) {
+    if (!GetCurrentDelegate(pBlock->GetTime(), vDelegatesAcctList, curDelegate)) {
         return false;
     }
 
@@ -337,16 +338,16 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
     CBlock preBlock;
 
     CBlockIndex* pblockindex = mapBlockIndex[pBlock->GetHashPrevBlock()];
-    if(pBlock->GetHashPrevBlock() != SysCfg().HashGenesisBlock()) {
-        if(!ReadBlockFromDisk(preBlock, pblockindex))
+    if (pBlock->GetHashPrevBlock() != SysCfg().HashGenesisBlock()) {
+        if (!ReadBlockFromDisk(preBlock, pblockindex))
             return ERRORMSG("read block info fail from disk");
 
         CAccount preDelegate;
         CRewardTransaction *preBlockRewardTx = (CRewardTransaction *) preBlock.vptx[0].get();
-        if(!view.GetAccount(preBlockRewardTx->account, preDelegate)) {
+        if (!view.GetAccount(preBlockRewardTx->account, preDelegate)) {
             return ERRORMSG("get preblock delegate account info error");
         }
-        if(pBlock->GetBlockTime()-preBlock.GetBlockTime() < SysCfg().GetTargetSpacing()) {
+        if (pBlock->GetBlockTime()-preBlock.GetBlockTime() < SysCfg().GetTargetSpacing()) {
              if(preDelegate.regID == curDelegate.regID) {
                 return ERRORMSG("one delegate can't produce more than one block at the same slot");
              }
@@ -362,9 +363,6 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
 
         if(!CheckSignScript(pBlock->SignatureHash(), pBlock->GetSignature(), account.PublicKey)) {
             if (!CheckSignScript(pBlock->SignatureHash(), pBlock->GetSignature(), account.MinerPKey)) {
-//              LogPrint("ERROR", "block verify fail\r\n");
-//              LogPrint("ERROR", "block hash:%s\n", pBlock->GetHash().GetHex());
-//              LogPrint("ERROR", "signature block:%s\n", HexStr(pBlock->vSignature.begin(), pBlock->vSignature.end()));
                 return ERRORMSG("Verify miner publickey signature error");
             }
         }
@@ -395,7 +393,7 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
                 return ERRORMSG("transaction UpdateAccount account error");
             }
             nTotalRunStep += pBaseTx->nRunStep;
-            if(nTotalRunStep > MAX_BLOCK_RUN_STEP) {
+            if (nTotalRunStep > MAX_BLOCK_RUN_STEP) {
                 return ERRORMSG("block total run steps exceed max run step");
             }
 
@@ -403,166 +401,154 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
             LogPrint("fuel", "VerifyPosTx total fuel:%d, tx fuel:%d runStep:%d fuelRate:%d txhash:%s \n",nTotalFuel, pBaseTx->GetFuel(pBlock->GetFuelRate()), pBaseTx->nRunStep, pBlock->GetFuelRate(), pBaseTx->GetHash().GetHex());
         }
 
-        if(nTotalFuel != pBlock->GetFuel()) {
+        if (nTotalFuel != pBlock->GetFuel()) {
             return ERRORMSG("fuel value at block header calculate error");
         }
     }
     return true;
 }
 
-CBlockTemplate* CreateNewBlock(CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache){
+CBlockTemplate* CreateNewBlock(CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache) {
 
-    //    // Create new block
-        auto_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
-        if (!pblocktemplate.get())
-            return NULL;
-        CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+    // Create new block
+    auto_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
+    if (!pblocktemplate.get())
+        return NULL;
+    CBlock *pblock = &pblocktemplate->block; // pointer for convenience
 
-        // Create coinbase tx
-        CRewardTransaction rtx;
+    // Create coinbase tx
+    CRewardTransaction rtx;
 
-        // Add our coinbase tx as first transaction
-        pblock->vptx.push_back(std::make_shared<CRewardTransaction>(rtx));
-        pblocktemplate->vTxFees.push_back(-1); // updated at end
-        pblocktemplate->vTxSigOps.push_back(-1); // updated at end
+    // Add our coinbase tx as first transaction
+    pblock->vptx.push_back(std::make_shared<CRewardTransaction>(rtx));
+    pblocktemplate->vTxFees.push_back(-1); // updated at end
+    pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 
-        // Largest block you're willing to create:
-        unsigned int nBlockMaxSize = SysCfg().GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
-        // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
-        nBlockMaxSize = max((unsigned int) 1000, min((unsigned int) (MAX_BLOCK_SIZE - 1000), nBlockMaxSize));
+    // Largest block you're willing to create:
+    unsigned int nBlockMaxSize = SysCfg().GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
+    // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
+    nBlockMaxSize = max((unsigned int) 1000, min((unsigned int) (MAX_BLOCK_SIZE - 1000), nBlockMaxSize));
 
-        // How much of the block should be dedicated to high-priority transactions,
-        // included regardless of the fees they pay
-        unsigned int nBlockPrioritySize = SysCfg().GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
-        nBlockPrioritySize = min(nBlockMaxSize, nBlockPrioritySize);
+    // How much of the block should be dedicated to high-priority transactions,
+    // included regardless of the fees they pay
+    unsigned int nBlockPrioritySize = SysCfg().GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
+    nBlockPrioritySize = min(nBlockMaxSize, nBlockPrioritySize);
 
-        // Minimum block size you want to create; block will be filled with free transactions
-        // until there are no more or the block reaches this size:
-        unsigned int nBlockMinSize = SysCfg().GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
-        nBlockMinSize = min(nBlockMaxSize, nBlockMinSize);
+    // Minimum block size you want to create; block will be filled with free transactions
+    // until there are no more or the block reaches this size:
+    unsigned int nBlockMinSize = SysCfg().GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
+    nBlockMinSize = min(nBlockMaxSize, nBlockMinSize);
 
-        // Collect memory pool transactions into the block
-        int64_t nFees = 0;
-        {
-            LOCK2(cs_main, mempool.cs);
-            CBlockIndex* pIndexPrev = chainActive.Tip();
-            pblock->SetFuelRate(GetElementForBurn(pIndexPrev));
+    // Collect memory pool transactions into the block
+    int64_t nFees = 0;
+    {
+        LOCK2(cs_main, mempool.cs);
+        CBlockIndex* pIndexPrev = chainActive.Tip();
+        pblock->SetFuelRate(GetElementForBurn(pIndexPrev));
 
-            // This vector will be sorted into a priority queue:
-            vector<TxPriority> vecPriority;
-            GetPriorityTx(vecPriority, pblock->GetFuelRate());
+        // This vector will be sorted into a priority queue:
+        vector<TxPriority> vecPriority;
+        GetPriorityTx(vecPriority, pblock->GetFuelRate());
 
-            // Collect transactions into block
-            uint64_t nBlockSize = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
-            uint64_t nBlockTx(0);
-            bool fSortedByFee(true);
-            uint64_t nTotalRunStep(0);
-            int64_t  nTotalFuel(0);
-            TxPriorityCompare comparer(fSortedByFee);
-            make_heap(vecPriority.begin(), vecPriority.end(), comparer);
+        // Collect transactions into block
+        uint64_t nBlockSize = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
+        uint64_t nBlockTx(0);
+        bool fSortedByFee(true);
+        uint64_t nTotalRunStep(0);
+        int64_t  nTotalFuel(0);
+        TxPriorityCompare comparer(fSortedByFee);
+        make_heap(vecPriority.begin(), vecPriority.end(), comparer);
 
-            while (!vecPriority.empty()) {
-                // Take highest priority transaction off the priority queue:
-                double dPriority = vecPriority.front().get<0>();
-                double dFeePerKb = vecPriority.front().get<1>();
-                shared_ptr<CBaseTransaction> stx = vecPriority.front().get<2>();
-                CBaseTransaction *pBaseTx = stx.get();
-                //const CTransaction& tx = *(vecPriority.front().get<2>());
+        while (!vecPriority.empty()) {
+            // Take highest priority transaction off the priority queue:
+            double dPriority = vecPriority.front().get<0>();
+            double dFeePerKb = vecPriority.front().get<1>();
+            shared_ptr<CBaseTransaction> stx = vecPriority.front().get<2>();
+            CBaseTransaction *pBaseTx = stx.get();
+            //const CTransaction& tx = *(vecPriority.front().get<2>());
 
-                pop_heap(vecPriority.begin(), vecPriority.end(), comparer);
-                vecPriority.pop_back();
+            pop_heap(vecPriority.begin(), vecPriority.end(), comparer);
+            vecPriority.pop_back();
 
-                // Size limits
-                unsigned int nTxSize = ::GetSerializeSize(*pBaseTx, SER_NETWORK, PROTOCOL_VERSION);
-                if (nBlockSize + nTxSize >= nBlockMaxSize)
-                    continue;
-                // Skip free transactions if we're past the minimum block size:
-                if (fSortedByFee && (dFeePerKb < CTransaction::nMinRelayTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
-                    continue;
+            // Size limits
+            unsigned int nTxSize = ::GetSerializeSize(*pBaseTx, SER_NETWORK, PROTOCOL_VERSION);
+            if (nBlockSize + nTxSize >= nBlockMaxSize)
+                continue;
+            // Skip free transactions if we're past the minimum block size:
+            if (fSortedByFee && (dFeePerKb < CTransaction::nMinRelayTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
+                continue;
 
-                // Prioritize by fee once past the priority size or we run out of high-priority
-                // transactions:
-                if (!fSortedByFee && ((nBlockSize + nTxSize >= nBlockPrioritySize) || !AllowFree(dPriority))) {
-                    fSortedByFee = true;
-                    comparer = TxPriorityCompare(fSortedByFee);
-                    make_heap(vecPriority.begin(), vecPriority.end(), comparer);
-                }
-
-                if(uint256() != std::move(txCache.IsContainTx(std::move(pBaseTx->GetHash())))) {
-                    LogPrint("INFO","CreateNewBlock duplicate tx\n");
-                    continue;
-                }
-
-                CTxUndo txundo;
-                CValidationState state;
-                if(pBaseTx->IsCoinBase()){
-                    ERRORMSG("TX type is coin base tx error......");
-            //      assert(0); //never come here
-                }
-                if (CONTRACT_TX == pBaseTx->nTxType) {
-                    LogPrint("vm", "tx hash=%s CreateNewBlock run contract\n", pBaseTx->GetHash().GetHex());
-                }
-                CAccountViewCache viewTemp(view, true);
-                CScriptDBViewCache scriptCacheTemp(scriptCache, true);
-                pBaseTx->nFuelRate = pblock->GetFuelRate();
-                if (!pBaseTx->ExecuteTx(nBlockTx + 1, viewTemp, state, txundo, pIndexPrev->nHeight + 1,
-                        txCache, scriptCacheTemp)) {
-                    continue;
-                }
-                // Run step limits
-                if(nTotalRunStep + pBaseTx->nRunStep >= MAX_BLOCK_RUN_STEP)
-                    continue;
-                assert(viewTemp.Flush());
-                assert(scriptCacheTemp.Flush());
-                nFees += pBaseTx->GetFee();
-                nBlockSize += stx->GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
-                nTotalRunStep += pBaseTx->nRunStep;
-                nTotalFuel += pBaseTx->GetFuel(pblock->GetFuelRate());
-                nBlockTx++;
-                pblock->vptx.push_back(stx);
-                LogPrint("fuel", "miner total fuel:%d, tx fuel:%d runStep:%d fuelRate:%d txhash:%s\n",nTotalFuel, pBaseTx->GetFuel(pblock->GetFuelRate()), pBaseTx->nRunStep, pblock->GetFuelRate(), pBaseTx->GetHash().GetHex());
+            // Prioritize by fee once past the priority size or we run out of high-priority
+            // transactions:
+            if (!fSortedByFee && ((nBlockSize + nTxSize >= nBlockPrioritySize) || !AllowFree(dPriority))) {
+                fSortedByFee = true;
+                comparer = TxPriorityCompare(fSortedByFee);
+                make_heap(vecPriority.begin(), vecPriority.end(), comparer);
             }
 
-            nLastBlockTx = nBlockTx;
-            nLastBlockSize = nBlockSize;
-            LogPrint("INFO","CreateNewBlock(): total size %u\n", nBlockSize);
+            if(uint256() != std::move(txCache.IsContainTx(std::move(pBaseTx->GetHash())))) {
+                LogPrint("INFO","CreateNewBlock duplicate tx\n");
+                continue;
+            }
 
-            assert(nFees-nTotalFuel >= 0);
-            ((CRewardTransaction*) pblock->vptx[0].get())->rewardValue = nFees - nTotalFuel;
-
-            // Fill in header
-            pblock->SetHashPrevBlock(pIndexPrev->GetBlockHash());
-            UpdateTime(*pblock, pIndexPrev);
-            pblock->SetNonce(0);
-            pblock->SetHeight(pIndexPrev->nHeight + 1);
-            pblock->SetFuel(nTotalFuel);
+            CTxUndo txundo;
+            CValidationState state;
+            if (pBaseTx->IsCoinBase()){
+                ERRORMSG("Tx type is coin base tx error......");
+            }
+            if (CONTRACT_TX == pBaseTx->nTxType) {
+                LogPrint("vm", "tx hash=%s CreateNewBlock run contract\n", pBaseTx->GetHash().GetHex());
+            }
+            CAccountViewCache viewTemp(view, true);
+            CScriptDBViewCache scriptCacheTemp(scriptCache, true);
+            pBaseTx->nFuelRate = pblock->GetFuelRate();
+            if (!pBaseTx->ExecuteTx(nBlockTx + 1, viewTemp, state, txundo, pIndexPrev->nHeight + 1,
+                    txCache, scriptCacheTemp)) {
+                continue;
+            }
+            // Run step limits
+            if(nTotalRunStep + pBaseTx->nRunStep >= MAX_BLOCK_RUN_STEP)
+                continue;
+            assert(viewTemp.Flush());
+            assert(scriptCacheTemp.Flush());
+            nFees += pBaseTx->GetFee();
+            nBlockSize += stx->GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+            nTotalRunStep += pBaseTx->nRunStep;
+            nTotalFuel += pBaseTx->GetFuel(pblock->GetFuelRate());
+            nBlockTx++;
+            pblock->vptx.push_back(stx);
+            LogPrint("fuel", "miner total fuel:%d, tx fuel:%d runStep:%d fuelRate:%d txhash:%s\n",
+                     nTotalFuel, pBaseTx->GetFuel(pblock->GetFuelRate()), pBaseTx->nRunStep,
+                     pblock->GetFuelRate(), pBaseTx->GetHash().GetHex());
         }
 
-        return pblocktemplate.release();
+        nLastBlockTx = nBlockTx;
+        nLastBlockSize = nBlockSize;
+        LogPrint("INFO","CreateNewBlock(): total size %u\n", nBlockSize);
+
+        assert(nFees-nTotalFuel >= 0);
+        ((CRewardTransaction*) pblock->vptx[0].get())->rewardValue = nFees - nTotalFuel;
+
+        // Fill in header
+        pblock->SetHashPrevBlock(pIndexPrev->GetBlockHash());
+        UpdateTime(*pblock, pIndexPrev);
+        pblock->SetNonce(0);
+        pblock->SetHeight(pIndexPrev->nHeight + 1);
+        pblock->SetFuel(nTotalFuel);
+    }
+
+    return pblocktemplate.release();
 }
 
 bool CheckWork(CBlock* pblock, CWallet& wallet) {
-
-
-    //// debug print
-//  LogPrint("INFO","proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
+    // Print block information
     pblock->print(*pAccountViewTip);
-    // LogPrint("INFO","generated %s\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
 
     // Found a solution
     {
         LOCK(cs_main);
         if (pblock->GetHashPrevBlock() != chainActive.Tip()->GetBlockHash())
             return ERRORMSG("CoinMiner : generated block is stale");
-
-        // Remove key from key pool
-    //  reservekey.KeepKey();
-
-        // Track how many getdata requests this block gets
-//      {
-//          LOCK(wallet.cs_wallet);
-//          wallet.mapRequestCount[pblock->GetHash()] = 0;
-//      }
 
         // Process this block the same as if we had received it from another node
         CValidationState state;
@@ -573,11 +559,12 @@ bool CheckWork(CBlock* pblock, CWallet& wallet) {
     return true;
 }
 
-bool static MineBlock(CBlock *pblock, CWallet *pwallet,CBlockIndex* pindexPrev,unsigned int nTransactionsUpdatedLast,CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache){
+bool static MineBlock(CBlock *pblock, CWallet *pwallet, CBlockIndex *pindexPrev, unsigned int nTransactionsUpdated,
+                      CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache) {
 
     int64_t nStart = GetTime();
 
-    unsigned int lasttime = 0xFFFFFFFF;
+    unsigned int nLastTime = 0xFFFFFFFF;
     while (true) {
 
         // Check for stop or if block needs to be rebuilt
@@ -588,87 +575,84 @@ bool static MineBlock(CBlock *pblock, CWallet *pwallet,CBlockIndex* pindexPrev,u
         if (pindexPrev != chainActive.Tip())
             return false;
 
-        //获取时间 同时等待下次时间到
         auto GetNextTimeAndSleep = [&]() {
-            while(GetTime() == lasttime  || (GetTime() - pindexPrev->GetBlockTime()) < SysCfg().GetTargetSpacing())
-            {
+            while (GetTime() == nLastTime  || (GetTime() - pindexPrev->GetBlockTime()) < SysCfg().GetTargetSpacing()) {
                 ::MilliSleep(100);
             }
-            return (lasttime = GetTime());
+            return (nLastTime = GetTime());
         };
 
-        GetNextTimeAndSleep();  // max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
+        GetNextTimeAndSleep();
 
         vector<CAccount> vDelegatesAcctList;
-        if(!GetDelegatesAcctList(vDelegatesAcctList)) {
+        if (!GetDelegatesAcctList(vDelegatesAcctList)) {
             return false;
         }
         int nIndex = 0;
-        for(auto & acct : vDelegatesAcctList) {
+        for (auto & acct : vDelegatesAcctList) {
             LogPrint("shuffle","before shuffle index=%d, address=%s\n", nIndex++, acct.keyID.ToAddress());
         }
         ShuffleDelegates(pblock->GetHeight(), vDelegatesAcctList);
         nIndex = 0;
-        for(auto & acct : vDelegatesAcctList) {
+        for (auto & acct : vDelegatesAcctList) {
             LogPrint("shuffle","after shuffle index=%d, address=%s\n", nIndex++, acct.keyID.ToAddress());
         }
         int64_t currentTime = GetTime();
         CAccount minerAcct;
-        if(!GetCurrentDelegate(currentTime, vDelegatesAcctList, minerAcct)) {
+        if (!GetCurrentDelegate(currentTime, vDelegatesAcctList, minerAcct)) {
             return false;
         }
 
-//        LogPrint("INFO", "Current charger delegate address=%s\n", minerAcct.keyID.ToAddress());
         bool createdFlag = false;
-        int64_t lasttime1;
+        int64_t nLastTime;
         {
             LOCK2(cs_main, pwalletMain->cs_wallet);
             if((unsigned int)(chainActive.Tip()->nHeight + 1) !=  pblock->GetHeight())
                 return false;
             CKey acctKey;
-            if(pwalletMain->GetKey(minerAcct.keyID.ToAddress(), acctKey, true) ||
+            if (pwalletMain->GetKey(minerAcct.keyID.ToAddress(), acctKey, true) ||
                     pwalletMain->GetKey(minerAcct.keyID.ToAddress(), acctKey)) {
-                lasttime1 = GetTimeMillis();
+                nLastTime = GetTimeMillis();
                 createdFlag = CreatePosTx(currentTime, minerAcct, view, pblock);
-                LogPrint("MINER", "CreatePosTx %s, used time:%d ms, miner address=%s\n", createdFlag ? "success" : "failure", GetTimeMillis() - lasttime1, minerAcct.keyID.ToAddress());
+                LogPrint("MINER", "CreatePosTx %s, used time:%d ms, miner address=%s\n", createdFlag ? "success" : "failure", GetTimeMillis() - nLastTime, minerAcct.keyID.ToAddress());
             }
         }
         if (createdFlag == true) {
             SetThreadPriority(THREAD_PRIORITY_NORMAL);
             {
-                lasttime1 = GetTimeMillis();
+                nLastTime = GetTimeMillis();
                 CheckWork(pblock, *pwallet);
-                LogPrint("MINER", "CheckWork used time:%d ms\n",   GetTimeMillis() - lasttime1);
+                LogPrint("MINER", "CheckWork used time:%d ms\n",   GetTimeMillis() - nLastTime);
             }
             SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
             return true;
         }
 
-        if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast || GetTime() - nStart > 60)
-                return false;
+        if (mempool.GetTransactionsUpdated() != nTransactionsUpdated || GetTime() - nStart > 60)
+            return false;
     }
     return false;
 }
 
-void static CoinMiner(CWallet *pwallet,int targetConter) {
-    LogPrint("INFO","CoinMiner started.\n");
+void static CoinMiner(CWallet *pwallet, int targetHeight) {
+    LogPrint("INFO", "CoinMiner started.\n");
 
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     RenameThread("Coin-miner");
 
     auto CheckIsHaveMinerKey = [&]() {
-            LOCK2(cs_main, pwalletMain->cs_wallet);
-            set<CKeyID> setMineKey;
-            setMineKey.clear();
-            pwalletMain->GetKeys(setMineKey, true);
-            return !setMineKey.empty();
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        set<CKeyID> setMineKey;
+        setMineKey.clear();
+        pwalletMain->GetKeys(setMineKey, true);
+        return !setMineKey.empty();
     };
 
     if (!CheckIsHaveMinerKey()) {
-            LogPrint("INFO", "CoinMiner terminated.\n");
-            ERRORMSG("ERROR:%s ", "no key for mining\n");
-            return ;
+        LogPrint("INFO", "CoinMiner terminated.\n");
+        ERRORMSG("ERROR:%s ", "No key for mining\n");
+        return;
     }
 
     auto getCurrHeight = [&]() {
@@ -676,10 +660,10 @@ void static CoinMiner(CWallet *pwallet,int targetConter) {
         return chainActive.Height();
     };
 
-    targetConter += getCurrHeight();
+    targetHeight += getCurrHeight();
 
     try {
-           SetMinerStatus(true);
+        SetMinerStatus(true);
         while (true) {
             if (SysCfg().NetworkID() != REGTEST_NET) {
                 // Busy-wait for the network to come online so we don't waste time mining
@@ -691,26 +675,26 @@ void static CoinMiner(CWallet *pwallet,int targetConter) {
             //
             // Create new block
             //
-            unsigned int LastTrsa = mempool.GetTransactionsUpdated();
+            unsigned int nTransactionsUpdated = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
-
-            CAccountViewCache accview(*pAccountViewTip, true);
+            CAccountViewCache accountView(*pAccountViewTip, true);
             CTransactionDBCache txCache(*pTxCacheTip, true);
-            CScriptDBViewCache ScriptDbTemp(*pScriptDBTip, true);
-            int64_t lasttime1 = GetTimeMillis();
-            shared_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(accview, txCache, ScriptDbTemp));
-            if (!pblocktemplate.get()){
+            CScriptDBViewCache scriptDB(*pScriptDBTip, true);
+            int64_t nLastTime = GetTimeMillis();
+            shared_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(accountView, txCache, scriptDB));
+            if (!pblocktemplate.get()) {
                 throw runtime_error("Create new block fail.");
             }
-            LogPrint("MINER", "CreateNewBlock tx count:%d used time :%d ms\n", pblocktemplate.get()->block.vptx.size(),
-                    GetTimeMillis() - lasttime1);
+            LogPrint("MINER", "CreateNewBlock tx count: %d used time: %d ms\n",
+                     pblocktemplate.get()->block.vptx.size(), GetTimeMillis() - nLastTime);
             CBlock *pblock = &pblocktemplate.get()->block;
-            MineBlock(pblock, pwallet, pindexPrev, LastTrsa, accview, txCache, ScriptDbTemp);
+            MineBlock(pblock, pwallet, pindexPrev, nTransactionsUpdated, accountView, txCache, scriptDB);
 
-            if (SysCfg().NetworkID() != MAIN_NET)
-                if(targetConter <= getCurrHeight()) {
-                        throw boost::thread_interrupted();
+            if (SysCfg().NetworkID() != MAIN_NET) {
+                if (targetHeight <= getCurrHeight()) {
+                    throw boost::thread_interrupted();
                 }
+            }
         }
     } catch (...) {
         LogPrint("INFO","CoinMiner  terminated\n");
@@ -724,22 +708,18 @@ void GenerateCoinBlock(bool fGenerate, CWallet* pwallet, int targetHeight) {
 
     if (minerThreads != NULL) {
         minerThreads->interrupt_all();
-//      minerThreads->join_all();
         delete minerThreads;
         minerThreads = NULL;
     }
 
-    if(targetHeight <= 0 && fGenerate == true)
-    {
-//      assert(0);
+    if (targetHeight <= 0 && fGenerate == true) {
         ERRORMSG("targetHeight, fGenerate value error");
         return ;
     }
+
     if (!fGenerate)
         return;
-    //in pos system one thread is enough  marked by ranger.shi
+
     minerThreads = new boost::thread_group();
     minerThreads->create_thread(boost::bind(&CoinMiner, pwallet, targetHeight));
-
-//  minerThreads->join_all();
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -55,10 +55,7 @@ public:
 
 /** Run the miner threads */
 void GenerateCoinBlock(bool fGenerate, CWallet* pwallet, int nThreads);
-/** Generate a new block, without valid proof-of-work */
-//CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
-//CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
-
+/** Generate a new block */
 CBlockTemplate* CreateNewBlock(CAccountViewCache &view, CTransactionDBCache &txCache, CScriptDBViewCache &scriptCache);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
@@ -83,8 +80,6 @@ void SHA256Transform(void* pstate, void* pinput, const void* pinit);
 int GetElementForBurn(CBlockIndex *pindex);
 
 void GetPriorityTx(vector<TxPriority> &vecPriority, int nFuelRate);
-//extern double dHashesPerSec;
-//extern int64_t nHPSTimerStart;
 
 extern uint256 CreateBlockWithAppointedAddr(CKeyID const &keyID);
 

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -186,12 +186,12 @@ Value setgenerate(const Array& params, bool fHelp)
     if (fGenerate == false){
         GenerateCoinBlock(false, pwalletMain, 1);
 
-        obj.push_back(Pair("msg","stoping  mining"));
+        obj.push_back(Pair("msg", "stoping  mining"));
         return obj;
     }
 
-    GenerateCoinBlock(true, pwalletMain, nGenProcLimit);//跑完之后需要退出
-    obj.push_back(Pair("msg","in  mining"));
+    GenerateCoinBlock(true, pwalletMain, nGenProcLimit);
+    obj.push_back(Pair("msg", "in  mining"));
     return obj;
 }
 

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -384,7 +384,7 @@ Value registeraccounttx(const Array& params, bool fHelp) {
     if (fee < nDefaultFee) {
         char errorMsg[100] = {'\0'};
         sprintf (errorMsg, "input fee smaller than mintxfee: %ld sawi", nDefaultFee);
-        throw JSONRPCError(RPC_INSUFFICIENT_FEE, errorMsg);  
+        throw JSONRPCError(RPC_INSUFFICIENT_FEE, errorMsg);
     }
 
     //get keyid


### PR DESCRIPTION
In mainet, coin miner should generate blocks continuously regardless of target height.

If one forget to add `genproclimit` in `WaykiChain.conf`, the coin miner thread will not be created with the error message in ERROR.log like this: `targetHeight, fGenerate value error`.