### PR TITLE
avoid integer overflow in GetMaxFee

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -294,7 +294,7 @@ public:
         return nSubsidyHalvingInterval;
     }
     virtual int64_t GetMaxFee() const {
-        return 1000 * 100000000; //1000 WICC
+        return 1000 * COIN;  //1000 WICC
     }
     virtual const CBlock& GenesisBlock() const = 0;
     virtual bool RequireRPCPassword() const {


### PR DESCRIPTION
**What's the problem?**

```code
./chainparams.h: In member function ‘virtual int64_t CBaseParams::GetMaxFee() const’:
./chainparams.h:297:23: warning: integer overflow in expression [-Woverflow]
         return 1000 * 100000000; //1000 WICC
```

the expression 1000 * 100000000 is evaluated as an int, with undefined results on some platform like 32-bit since you are overflowing the int type.

FYI, visit [cpp-error-integer-overflow-in-expression](https://stackoverflow.com/questions/47218311/cpp-error-integer-overflow-in-expression)