### PR TITLE
refactor: split CTransaction according to nTxType

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -305,8 +305,8 @@ string HelpMessage() {
         strUsage += "  -limitfreerelay=<n>    " + _("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default:15)") + "\n";
         strUsage += "  -maxsigcachesize=<n>   " + _("Limit size of signature cache to <n> entries (default: 50000)") + "\n";
     }
-    strUsage += "  -mintxfee=<amt>        " + _("Fees smaller than this are considered zero fee (for transaction creation) (default:") + " " + FormatMoney(CTransaction::nMinTxFee) + ")" + "\n";
-    strUsage += "  -minrelaytxfee=<amt>   " + _("Fees smaller than this are considered zero fee (for relaying) (default:") + " " + FormatMoney(CTransaction::nMinRelayTxFee) + ")" + "\n";
+    strUsage += "  -mintxfee=<amt>        " + _("Fees smaller than this are considered zero fee (for transaction creation) (default:") + " " + FormatMoney(CBaseTransaction::nMinTxFee) + ")" + "\n";
+    strUsage += "  -minrelaytxfee=<amt>   " + _("Fees smaller than this are considered zero fee (for relaying) (default:") + " " + FormatMoney(CBaseTransaction::nMinRelayTxFee) + ")" + "\n";
     strUsage += "  -logprinttoconsole     " + _("Send trace/debug info to console instead of debug.log file") + "\n";
     if (SysCfg().GetBoolArg("-help-debug", false)) {
         strUsage += "  -printblock=<hash>     " + _("Print block on startup, if found in block index") + "\n";
@@ -548,7 +548,7 @@ bool AppInit(boost::thread_group &threadGroup) {
     if (SysCfg().IsArgCount("-mintxfee")) {
         int64_t n = 0;
         if (ParseMoney(SysCfg().GetArg("-mintxfee", ""), n) && n > 0) {
-            CTransaction::nMinTxFee = n;
+            CBaseTransaction::nMinTxFee = n;
         } else {
             return InitError(strprintf(_("Invalid amount for -mintxfee=<amount>: '%s'"), SysCfg().GetArg("-mintxfee", "")));
         }
@@ -556,7 +556,7 @@ bool AppInit(boost::thread_group &threadGroup) {
     if (SysCfg().IsArgCount("-minrelaytxfee")) {
         int64_t n = 0;
         if (ParseMoney(SysCfg().GetArg("-minrelaytxfee", ""), n) && n > 0) {
-            CTransaction::nMinRelayTxFee = n;
+            CBaseTransaction::nMinRelayTxFee = n;
         } else {
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), SysCfg().GetArg("-minrelaytxfee", "")));
         }

--- a/src/main.h
+++ b/src/main.h
@@ -282,12 +282,6 @@ struct CDiskTxPos : public CDiskBlockPos {
 
 int64_t GetMinRelayFee(const CBaseTransaction *pBaseTx, unsigned int nBytes, bool fAllowFree);
 
-/** Count ECDSA signature operations the old-fashioned (pre-0.6) way
-    @return number of sigops this transaction's outputs will produce when spent
-    @see CTransaction::FetchInputs
-*/
-unsigned int GetLegacySigOpCount(const CTransaction &tx);
-
 inline bool AllowFree(double dPriority) {
     // Large (in bytes) low-priority (new, small-coin) transactions
     // need a fee.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -41,44 +41,6 @@ const int MINED_BLOCK_COUNT_MAX = 100; // the max count of mined blocks will be 
 static const unsigned int pSHA256InitState[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
                                                  0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
 
-//void SHA256Transform(void* pstate, void* pinput, const void* pinit) {
-//  SHA256_CTX ctx;
-//  unsigned char data[64];
-//
-//  SHA256_Init(&ctx);
-//
-//  for (int i = 0; i < 16; i++)
-//      ((uint32_t*) data)[i] = ByteReverse(((uint32_t*) pinput)[i]);
-//
-//  for (int i = 0; i < 8; i++)
-//      ctx.h[i] = ((uint32_t*) pinit)[i];
-//
-//  SHA256_Update(&ctx, data, sizeof(data));
-//  for (int i = 0; i < 8; i++)
-//      ((uint32_t*) pstate)[i] = ctx.h[i];
-//}
-
-// Some explaining would be appreciated
-class COrphan {
-   public:
-    const CTransaction *ptx;
-    set<uint256> setDependsOn;
-    double dPriority;
-    double dFeePerKb;
-
-    COrphan(const CTransaction *ptxIn) {
-        ptx       = ptxIn;
-        dPriority = dFeePerKb = 0;
-    }
-
-    void Print() const {
-        LogPrint("INFO", "COrphan(hash=%s, dPriority=%.1f, dFeePerKb=%.1f)\n",
-                 ptx->GetHash().ToString(), dPriority, dFeePerKb);
-        for (const auto &hash : setDependsOn)
-            LogPrint("INFO", "   setDependsOn %s\n", hash.ToString());
-    }
-};
-
 uint64_t nLastBlockTx   = 0;  // 块中交易的总笔数,不含coinbase
 uint64_t nLastBlockSize = 0;  // 被创建的块的尺寸
 
@@ -266,8 +228,7 @@ void ShuffleDelegates(const int nCurHeight, vector<CAccount> &vDelegatesList) {
 }
 
 bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionDBCache &txCache,
-                 CScriptDBViewCache &scriptCache, bool bNeedRunTx)
-{
+                 CScriptDBViewCache &scriptCache, bool bNeedRunTx) {
     uint64_t maxNonce = SysCfg().GetBlockMaxNonce();
     vector<CAccount> vDelegatesAcctList;
 
@@ -322,7 +283,7 @@ bool VerifyPosTx(const CBlock *pBlock, CAccountViewCache &accView, CTransactionD
     }
 
     if (prtx->nVersion != nTxVersion1)
-        return ERRORMSG("CTransaction CheckTransaction,tx version is not equal current version, (tx version %d: vs current %d)",
+        return ERRORMSG("Verify tx version error, tx version %d: vs current %d",
             prtx->nVersion, nTxVersion1);
 
     if (bNeedRunTx) {
@@ -424,7 +385,7 @@ CBlockTemplate *CreateNewBlock(CAccountViewCache &view, CTransactionDBCache &txC
                 continue;
 
             // Skip free transactions if we're past the minimum block size:
-            if ((dFeePerKb < CTransaction::nMinRelayTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
+            if ((dFeePerKb < CBaseTransaction::nMinRelayTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
                 continue;
 
             CTxUndo txundo;

--- a/src/miner.h
+++ b/src/miner.h
@@ -24,7 +24,6 @@ struct CBlockTemplate;
 //class CScript;
 class CWallet;
 class CBaseTransaction;
-class COrphan;
 class CAccountViewCache;
 class CTransactionDBCache;
 class CScriptDBViewCache;

--- a/src/net.h
+++ b/src/net.h
@@ -722,9 +722,6 @@ public:
     static uint64_t GetTotalBytesSent();
 };
 
-
-
-class CTransaction;
 void RelayTransaction(CBaseTransaction *pBaseTx, const uint256& hash);
 void RelayTransaction(CBaseTransaction *pBaseTx, const uint256& hash, const CDataStream& ss);
 

--- a/src/rpc/rpcblockchain.cpp
+++ b/src/rpc/rpcblockchain.cpp
@@ -164,7 +164,7 @@ Value getrawmempool(const Array& params, bool fHelp)
 
     if (fVerbose) {
         LOCK(mempool.cs);
-        Object o;
+        Object obj;
         for (const auto& entry : mempool.mapTx) {
             const uint256& hash = entry.first;
             const CTxMemPoolEntry& e = entry.second;
@@ -175,27 +175,21 @@ Value getrawmempool(const Array& params, bool fHelp)
             info.push_back(Pair("height", (int)e.GetHeight()));
             info.push_back(Pair("startingpriority", e.GetPriority(e.GetHeight())));
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
-//            const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-//            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-//            {
-//                if (mempool.Exists(txin.prevout.hash))
-//                    setDepends.insert(txin.prevout.hash.ToString());
-//            }
             Array depends(setDepends.begin(), setDepends.end());
             info.push_back(Pair("depends", depends));
-            o.push_back(Pair(hash.ToString(), info));
+            obj.push_back(Pair(hash.ToString(), info));
         }
-        return o;
+        return obj;
     } else {
         vector<uint256> vtxid;
         mempool.QueryHash(vtxid);
 
-        Array a;
+        Array arr;
         for (const auto& hash : vtxid)
-            a.push_back(hash.ToString());
+            arr.push_back(hash.ToString());
 
-        return a;
+        return arr;
     }
 }
 

--- a/src/rpc/rpcmisc.cpp
+++ b/src/rpc/rpcmisc.cpp
@@ -92,7 +92,7 @@ Value getbalance(const Array& params, bool fHelp)
                         map<uint256, std::shared_ptr<CBaseTransaction> > mapTx = pwalletMain->mapInBlockTx[pBlockIndex->GetBlockHash()].mapAccountTx;
                         for (auto &item : mapTx) {
                             if (COMMON_TX == item.second->nTxType) {
-                                CTransaction *pTx = (CTransaction *) item.second.get();
+                                CCommonTransaction *pTx = (CCommonTransaction *)item.second.get();
                                 CKeyID srcKeyId, desKeyId;
                                 pAccountViewTip->GetKeyId(pTx->srcRegId, srcKeyId);
                                 pAccountViewTip->GetKeyId(pTx->desUserId, desKeyId);
@@ -125,7 +125,7 @@ Value getbalance(const Array& params, bool fHelp)
                             map<uint256, std::shared_ptr<CBaseTransaction> > mapTx = pwalletMain->mapInBlockTx[pBlockIndex->GetBlockHash()].mapAccountTx;
                             for (auto &item : mapTx) {
                                 if (COMMON_TX == item.second->nTxType) {
-                                    CTransaction *pTx = (CTransaction *) item.second.get();
+                                    CCommonTransaction *pTx = (CCommonTransaction *)item.second.get();
                                     CKeyID srcKeyId, desKeyId;
                                     pAccountViewTip->GetKeyId(pTx->desUserId, desKeyId);
                                     if (keyid == desKeyId) {
@@ -217,7 +217,7 @@ Value getinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("unlockeduntil", nWalletUnlockTime));
 
     obj.push_back(Pair("paytxfee",          ValueFromAmount(SysCfg().GetTxFee())));
-    obj.push_back(Pair("relayfee",          ValueFromAmount(CTransaction::nMinRelayTxFee)));
+    obj.push_back(Pair("relayfee",          ValueFromAmount(CBaseTransaction::nMinRelayTxFee)));
     obj.push_back(Pair("fuelrate",          chainActive.Tip()->nFuelRate));
     obj.push_back(Pair("fuel",              chainActive.Tip()->nFuel));
     obj.push_back(Pair("confdir",           GetConfigFile().string().c_str()));

--- a/src/rpc/rpcnet.cpp
+++ b/src/rpc/rpcnet.cpp
@@ -157,8 +157,8 @@ Value addnode(const Array& params, bool fHelp)
             "\nArguments:\n"
             "1. \"node:port\"     (string, required) The node IP and port (see getpeerinfo for nodes)\n"
             "2. \"command\"  (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once\n"
-			"\nResult:\n"
-        	"\nExamples:\n"
+            "\nResult:\n"
+            "\nExamples:\n"
             + HelpExampleCli("addnode", "\"192.168.0.6:8333\" onetry")
             + HelpExampleRpc("addnode", "\"192.168.0.6:8333\", onetry")
         );
@@ -341,7 +341,7 @@ Value getnetworkinfo(const Array& params, bool fHelp)
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getnetworkinfo\n"
-			"\nget various information about network.\n"
+            "\nget various information about network.\n"
             "Returns an object containing various state info regarding P2P networking.\n"
             "\nResult:\n"
             "{\n"
@@ -371,7 +371,7 @@ Value getnetworkinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string())));
-    obj.push_back(Pair("relayfee",      ValueFromAmount(CTransaction::nMinRelayTxFee)));
+    obj.push_back(Pair("relayfee",      ValueFromAmount(CBaseTransaction::nMinRelayTxFee)));
     Array localAddresses;
     {
         LOCK(cs_mapLocalHost);
@@ -396,14 +396,14 @@ Value getchainstate(const Array& params, bool fHelp)
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getchainstate \"num\"\n"
-			"\nget the chain state by the most recent blocks.\n"
+            "\nget the chain state by the most recent blocks.\n"
             "\nArguments:\n"
             "1.num   (numeric,required, > 0) The number of the most recent blocks.\n"
             "\nResult:\n"
             "{\n"
             "  \"blocktime\": n,   (numeric) the time of each block\n"
             "  \"transactions\": n, (numeric) number of transactions within each block\n"
-        	"  \"fuel\": n, (numeric) fuel of each block\n"
+            "  \"fuel\": n, (numeric) fuel of each block\n"
             "  \"miner\": n, (string) RegId of the miner of each block\n"
             "}\n"
             "\nExamples:\n"
@@ -411,38 +411,38 @@ Value getchainstate(const Array& params, bool fHelp)
             + HelpExampleRpc("getchainstate", "\"5\"")
        );
 
-	int i = 0,nHeight = 0;
-	if (int_type == params[0].type()) {
-		nHeight = params[0].get_int();
-		if(nHeight < 1)
-			throw runtime_error("Block number out of range.");
-	    if(nHeight > chainActive.Height()) {   //防止超过最大高度
-	    	nHeight = chainActive.Height();
-	    }
-	}
-	CBlockIndex * pBlockIndex = chainActive.Tip();
-	CBlock block;
-	Array blocktime;
-	Array difficulty;
-	Array transactions;
-	Array fuel;
-	Array blockminer;
+    int i = 0,nHeight = 0;
+    if (int_type == params[0].type()) {
+        nHeight = params[0].get_int();
+        if(nHeight < 1)
+            throw runtime_error("Block number out of range.");
+        if(nHeight > chainActive.Height()) {   //防止超过最大高度
+            nHeight = chainActive.Height();
+        }
+    }
+    CBlockIndex * pBlockIndex = chainActive.Tip();
+    CBlock block;
+    Array blocktime;
+    Array difficulty;
+    Array transactions;
+    Array fuel;
+    Array blockminer;
 
-	for (i = 0; (i < nHeight) && (pBlockIndex != NULL); i++) {
-		blocktime.push_back(pBlockIndex->GetBlockTime());
-		transactions.push_back((int)pBlockIndex->nTx);
-		fuel.push_back(pBlockIndex->nFuel);
-		block.SetNull();
-		if (ReadBlockFromDisk(block, pBlockIndex)) {
-			string miner(boost::get<CRegID>(dynamic_pointer_cast<CRewardTransaction>(block.vptx[0])->account).ToString());
-			blockminer.push_back(move(miner));
-		}
-		pBlockIndex = pBlockIndex->pprev;
-	}
-	Object obj;
-	obj.push_back(Pair("blocktime", blocktime));
-	obj.push_back(Pair("transactions", transactions));
-	obj.push_back(Pair("fuel", fuel));
-	obj.push_back(Pair("miner",blockminer));
+    for (i = 0; (i < nHeight) && (pBlockIndex != NULL); i++) {
+        blocktime.push_back(pBlockIndex->GetBlockTime());
+        transactions.push_back((int)pBlockIndex->nTx);
+        fuel.push_back(pBlockIndex->nFuel);
+        block.SetNull();
+        if (ReadBlockFromDisk(block, pBlockIndex)) {
+            string miner(boost::get<CRegID>(dynamic_pointer_cast<CRewardTransaction>(block.vptx[0])->account).ToString());
+            blockminer.push_back(move(miner));
+        }
+        pBlockIndex = pBlockIndex->pprev;
+    }
+    Object obj;
+    obj.push_back(Pair("blocktime", blocktime));
+    obj.push_back(Pair("transactions", transactions));
+    obj.push_back(Pair("fuel", fuel));
+    obj.push_back(Pair("miner",blockminer));
     return obj;
 }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -32,7 +32,8 @@ class CAutoFile;
 class CDataStream;
 class CBaseTransaction;
 class CRegisterAccountTx;
-class CTransaction;
+class CCommonTransaction;
+class CContractTransaction;
 class CRewardTransaction;
 
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -21,9 +21,8 @@
 #include <boost/test/unit_test.hpp>
 
 // Tests this internal-to-main.cpp method:
-extern bool AddOrphanTx(const CTransaction& tx);
 extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans);
-extern std::map<uint256, CTransaction> mapOrphanTransactions;
+extern std::map<uint256, CCommonTransaction> mapOrphanTransactions;
 
 CService ip(uint32_t i) {
     struct in_addr s;
@@ -153,9 +152,9 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
     BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));
 }
 
-CTransaction RandomOrphan()
+CCommonTransaction RandomOrphan()
 {
-    std::map<uint256, CTransaction>::iterator it;
+    std::map<uint256, CCommonTransaction>::iterator it;
     it = mapOrphanTransactions.lower_bound(GetRandHash());
     if (it == mapOrphanTransactions.end())
     it = mapOrphanTransactions.begin();

--- a/src/test/appacc_test.cpp
+++ b/src/test/appacc_test.cpp
@@ -45,8 +45,8 @@ bool CheckAppAcct(int64_t opValue[]) {
 
     CUserID srcUserId= srcRegId;
     CUserID desUserId = desRegId;
-    vector_unsigned_char pContract;
-    CTransaction tx(srcUserId, desRegId, 10000, opValue[0], 1, pContract); //100 * COIN
+    vector_unsigned_char arguments;
+    CContractTransaction tx(srcUserId, desRegId, 10000, opValue[0], 1, arguments); //100 * COIN
 
     CVmRunEnv vmRunEnv;
     vector<CVmOperate> vAcctOper;

--- a/src/test/betroll_test.cpp
+++ b/src/test/betroll_test.cpp
@@ -839,7 +839,7 @@ unsigned char TempArray[] = {
 //	contractScript.scriptId = scriptId.vRegID;
 //	contractScript.scriptContent = vpscript;
 //	CSecureTransaction *nTemp = static_cast<CSecureTransaction*>(Tx[0].get());
-//	nTemp->vContract.insert(nTemp->vContract.begin(),VmData.begin(),VmData.end());
+//	nTemp->arguments.insert(nTemp->arguments.begin(),VmData.begin(),VmData.end());
 //	nTemp->regScriptId = scriptId.vRegID;
 //
 //	for (auto& item : account) {
@@ -848,11 +848,11 @@ unsigned char TempArray[] = {
 //	unsigned char ch; memcpy(&ch,&a2,1);
 //	CAppealTransaction *nA2 = static_cast<CAppealTransaction*>(Tx[1].get());
 //	nA2->vPreAcountIndex.push_back(0x00);
-//	nA2->vContract.push_back(ch);
+//	nA2->arguments.push_back(ch);
 //	memcpy(&ch,&b2,1);
 //	CAppealTransaction *nB2 = static_cast<CAppealTransaction*>(Tx[2].get());
 //	nB2->vPreAcountIndex.push_back(0x01);
-//	nB2->vContract.push_back(ch);
+//	nB2->arguments.push_back(ch);
 //}
 //struct CTxBetRollScript {
 //	CVmScript vscript;
@@ -912,9 +912,9 @@ unsigned char TempArray[] = {
 //			int b2 = random(100);
 //			unsigned char ch;
 //			memcpy(&ch, &b2, 1);
-//			if (ch != betroll->A2.get()->vContract[0]) {
-//				betroll->A2.get()->vContract.clear();
-//				betroll->A2.get()->vContract.push_back(ch);
+//			if (ch != betroll->A2.get()->arguments[0]) {
+//				betroll->A2.get()->arguments.clear();
+//				betroll->A2.get()->arguments.push_back(ch);
 //				break;
 //			}
 //		}
@@ -947,9 +947,9 @@ unsigned char TempArray[] = {
 //			int b2 = random(100);
 //			unsigned char ch;
 //			memcpy(&ch, &b2, 1);
-//			if (ch != betroll->B2.get()->vContract[0]) {
-//				betroll->B2.get()->vContract.clear();
-//				betroll->B2.get()->vContract.push_back(ch);
+//			if (ch != betroll->B2.get()->arguments[0]) {
+//				betroll->B2.get()->arguments.clear();
+//				betroll->B2.get()->arguments.push_back(ch);
 //				break;
 //			}
 //		}
@@ -1083,22 +1083,22 @@ unsigned char TempArray[] = {
 //	CDataStream VmData(SER_DISK, CLIENT_VERSION);
 //	VmData << vscript;
 //	string strOutpud = "script:" + HexStr(VmData.str())+"\r\n"
-//	+"first:" +HexStr(tx.get()->vContract)+"\r\n"
-//	+"A Second:" +HexStr(A2.get()->vContract)+"\r\n"
-//	+"B Third:"+HexStr(B2.get()->vContract)+"\r\n"
+//	+"first:" +HexStr(tx.get()->arguments)+"\r\n"
+//	+"A Second:" +HexStr(A2.get()->arguments)+"\r\n"
+//	+"B Third:"+HexStr(B2.get()->arguments)+"\r\n"
 //	+"or \r\n"
-//	+"B Second:"+HexStr(B2.get()->vContract)+"\r\n"
-//	+"A third:"+HexStr(A2.get()->vContract)+"\r\n";
+//	+"B Second:"+HexStr(B2.get()->arguments)+"\r\n"
+//	+"A third:"+HexStr(A2.get()->arguments)+"\r\n";
 //
 //	BOOST_MESSAGE(strOutpud);
 ////	cout << "script:" << HexStr(VmData.str()).c_str() << endl;
 ////
-////	cout<<"first:"<<HexStr(tx.get()->vContract).c_str()<<endl;
-////	cout<<"A Second:"<<HexStr(A2.get()->vContract).c_str()<<endl;
-////	cout<<"B Third:"<<HexStr(B2.get()->vContract).c_str()<<endl;
+////	cout<<"first:"<<HexStr(tx.get()->arguments).c_str()<<endl;
+////	cout<<"A Second:"<<HexStr(A2.get()->arguments).c_str()<<endl;
+////	cout<<"B Third:"<<HexStr(B2.get()->arguments).c_str()<<endl;
 ////	cout<<"or "<<endl;
-////	cout<<"B Second:"<<HexStr(B2.get()->vContract).c_str()<<endl;
-////	cout<<"A third:"<<HexStr(A2.get()->vContract).c_str()<<endl;
+////	cout<<"B Second:"<<HexStr(B2.get()->arguments).c_str()<<endl;
+////	cout<<"A third:"<<HexStr(A2.get()->arguments).c_str()<<endl;
 //}
 //
 //#else

--- a/src/vm/lmylib.cpp
+++ b/src/vm/lmylib.cpp
@@ -807,8 +807,8 @@ static int ExGetTxContractFunc(lua_State *L) {
     int len = 0;
     if (GetTransaction(pBaseTx, hash, *pVmRunEnv->GetScriptDB(), false)) {
         if (pBaseTx->nTxType == CONTRACT_TX) {
-            CTransaction *tx = static_cast<CTransaction *>(pBaseTx.get());
-            len = RetRstToLua(L, tx->vContract);
+            CContractTransaction *tx = static_cast<CContractTransaction *>(pBaseTx.get());
+            len = RetRstToLua(L, tx->arguments);
         } else {
             return RetFalse("ExGetTxContractFunc, tx type error");
         }
@@ -869,8 +869,12 @@ static int ExGetTxRegIDFunc(lua_State *L) {
     std::shared_ptr<CBaseTransaction> pBaseTx;
     int len = 0;
     if (GetTransaction(pBaseTx, hash, *pVmRunEnv->GetScriptDB(), false)) {
-        if (pBaseTx->nTxType == COMMON_TX || pBaseTx->nTxType == CONTRACT_TX) {
-            CTransaction *tx = static_cast<CTransaction*>(pBaseTx.get());
+        if (pBaseTx->nTxType == COMMON_TX) {
+            CCommonTransaction *tx = static_cast<CCommonTransaction*>(pBaseTx.get());
+            vector<unsigned char> item = boost::get<CRegID>(tx->srcRegId).GetVec6();
+            len = RetRstToLua(L, item);
+        } else if (pBaseTx->nTxType == CONTRACT_TX) {
+            CContractTransaction *tx = static_cast<CContractTransaction*>(pBaseTx.get());
             vector<unsigned char> item = boost::get<CRegID>(tx->srcRegId).GetVec6();
             len = RetRstToLua(L, item);
         } else {

--- a/src/vm/vmrunenv.h
+++ b/src/vm/vmrunenv.h
@@ -157,7 +157,7 @@ public:
 	shared_ptr<vector<CScriptDBOperLog> > GetDbLog();
 
 	bool GetAppUserAccount(const vector<unsigned char> &id, shared_ptr<CAppUserAccount> &sptrAcc);
-	bool CheckAppAcctOperate(CTransaction* tx);
+	bool CheckAppAcctOperate(CContractTransaction* tx);
 	void SetCheckAccount(bool bCheckAccount);
 	virtual ~CVmRunEnv();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -249,12 +249,11 @@ void CWallet::SyncTransaction(const uint256 &hash, CBaseTransaction*pTx, const C
             int i=0;
             for (const auto &sptx : pblock->vptx) {
                 uint256 hashtx = sptx->GetHash();
-                if(sptx->nTxType == CONTRACT_TX){
-                    string thisapp = boost::get<CRegID>(static_cast<CTransaction const*>(sptx.get())->desUserId).ToString();
-                    auto it = find_if(monitoring_appid->begin(), monitoring_appid->end(), [&](const string& appid) {
-                        return appid ==  thisapp;});
-                    if(monitoring_appid->end() != it)
-                    uiInterface.RevAppTransaction(pblock, i);
+                if (sptx->nTxType == CONTRACT_TX) {
+                    string thisapp = boost::get<CRegID>(static_cast<CContractTransaction const *>(sptx.get())->desUserId).ToString();
+                    auto it = find_if(monitoring_appid->begin(), monitoring_appid->end(),
+                                      [&](const string &appid) { return appid == thisapp; });
+                    if (monitoring_appid->end() != it) uiInterface.RevAppTransaction(pblock, i);
                 }
                 //confirm the tx is mine
                 if (IsMine(sptx.get())) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -329,8 +329,10 @@ public:
     bool AddTx(const uint256 &hash, const CBaseTransaction *pTx) {
         switch (pTx->nTxType) {
         case COMMON_TX:
+            mapAccountTx[hash] = std::make_shared<CCommonTransaction>(pTx);
+            break;
         case CONTRACT_TX:
-            mapAccountTx[hash] = std::make_shared<CTransaction>(pTx);
+            mapAccountTx[hash] = std::make_shared<CContractTransaction>(pTx);
             break;
         case REG_ACCT_TX:
             mapAccountTx[hash] = std::make_shared<CRegisterAccountTx>(pTx);


### PR DESCRIPTION
In order to simplify, split CTransacton into CCommonTransaction and CContractTransaction according to nTxType.