### PR TITLE
set the "CFLAGS=-fPIC"  for liblua53.a only

### DIFF
--- a/linuxshell/autogen-coin-man.sh
+++ b/linuxshell/autogen-coin-man.sh
@@ -46,4 +46,4 @@ done
 srcdir="$(dirname $0)"
 cd "$srcdir"
 autoreconf --install --force
-CFLAGS="-fPIC" ./configure --disable-upnp-default --without-gui --with-incompatible-bdb $Modules
+./configure --disable-upnp-default --without-gui --with-incompatible-bdb $Modules

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -270,6 +270,8 @@ if TARGET_WINDOWS
 coind_SOURCES += coind-res.rc
 endif
 
+liblua53_a_CFLAGS = -fPIC
+
 AM_CPPFLAGS += $(BDB_CPPFLAGS)
 coind_LDADD += $(BOOST_LIBS) $(BDB_LIBS)
 


### PR DESCRIPTION
this change fix the compiling err for liblua53.a as forllow:
```
/usr/bin/ld: liblua53.a(lapi.o): relocation R_X86_64_32 against `luaO_nilobject_' can not be used when making a shared object; recompile with -fPIC
liblua53.a: error adding symbols: Bad value
```