### PR TITLE
fix: implementation error in rpc listtxbyaddr 

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -711,23 +711,25 @@ bool CScriptDBViewCache::WriteTxOutPut(const uint256 &txid, const vector<CVmOper
     return SetData(vKey, vValue);
 }
 
-bool CScriptDBViewCache::SetTxHashByAddress(const CKeyID &keyId, int nHeight, int nIndex, const string &strTxHash, CScriptDBOperLog &operLog) {
+bool CScriptDBViewCache::SetTxHashByAddress(const CKeyID &keyId, int nHeight, int nIndex,
+                                            const string &strTxHash, CScriptDBOperLog &operLog) {
     vector<unsigned char> vKey = {'A', 'D', 'D', 'R'};
-    vector<unsigned char> oldValue;
-    oldValue.clear();
-    GetData(vKey, oldValue);
-    operLog = CScriptDBOperLog(vKey, oldValue);
 
     CDataStream ds1(SER_DISK, CLIENT_VERSION);
     ds1 << keyId;
     ds1 << nHeight;
-    ds1 << nIndex;
     vKey.insert(vKey.end(), ds1.begin(), ds1.end());
     vector<unsigned char> vValue(strTxHash.begin(), strTxHash.end());
+
+    vector<unsigned char> oldValue;
+    oldValue.clear();
+    GetData(vKey, oldValue);
+    operLog = CScriptDBOperLog(vKey, oldValue);
     return SetData(vKey, vValue);
 }
 
-bool CScriptDBViewCache::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &vTxHash) {
+bool CScriptDBViewCache::GetTxHashByAddress(
+    const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &vTxHash) {
     pBase->GetTxHashByAddress(keyId, nHeight, vTxHash);
 
     vector<unsigned char> vPreKey = {'A', 'D', 'D', 'R'};
@@ -736,22 +738,26 @@ bool CScriptDBViewCache::GetTxHashByAddress(const CKeyID &keyId, int nHeight, ma
     ds1 << nHeight;
     vPreKey.insert(vPreKey.end(), ds1.begin(), ds1.end());
 
-    map<vector<unsigned char>, vector<unsigned char> >::iterator iterFindKey = mapContractDb.upper_bound(vPreKey);
+    map<vector<unsigned char>, vector<unsigned char> >::iterator iterFindKey =
+        mapContractDb.upper_bound(vPreKey);
     while (iterFindKey != mapContractDb.end()) {
-        if (0 == memcmp((char *)&iterFindKey->first[0], (char *)&vPreKey[0], 24)) {
+        if (0 == memcmp((char *)&iterFindKey->first[0], (char *)&vPreKey[0], 28)) {
             if (iterFindKey->second.empty())
                 vTxHash.erase(iterFindKey->first);
             else {
                 vTxHash.insert(make_pair(iterFindKey->first, iterFindKey->second));
             }
-            ++iterFindKey;
         } else {
             break;
         }
     }
     return true;
 }
-bool CScriptDBViewCache::GetAllScriptAcc(const CRegID &scriptId, map<vector<unsigned char>, vector<unsigned char> > &mapAcc) { return pBase->GetAllScriptAcc(scriptId, mapAcc); }
+
+bool CScriptDBViewCache::GetAllScriptAcc(
+    const CRegID &scriptId, map<vector<unsigned char>, vector<unsigned char> > &mapAcc) {
+    return pBase->GetAllScriptAcc(scriptId, mapAcc);
+}
 
 bool CScriptDBViewCache::ReadTxOutPut(const uint256 &txid, vector<CVmOperate> &vOutput) {
     vector<unsigned char> vKey = {'o', 'u', 't', 'p', 'u', 't'};

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -436,7 +436,7 @@ bool CScriptDBView::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) { return f
 bool CScriptDBView::WriteTxIndex(const vector<pair<uint256, CDiskTxPos> > &list, vector<CScriptDBOperLog> &vTxIndexOperDB) { return false; }
 bool CScriptDBView::WriteTxOutPut(const uint256 &txid, const vector<CVmOperate> &vOutput, CScriptDBOperLog &operLog) { return false; }
 bool CScriptDBView::ReadTxOutPut(const uint256 &txid, vector<CVmOperate> &vOutput) { return false; }
-bool CScriptDBView::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &vTxHash) { return false; }
+bool CScriptDBView::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &mapTxHash) { return false; }
 bool CScriptDBView::SetTxHashByAddress(const CKeyID &keyId, int nHeight, int nIndex, const string &strTxHash, CScriptDBOperLog &operLog) { return false; }
 bool CScriptDBView::GetAllScriptAcc(const CRegID &scriptId, map<vector<unsigned char>, vector<unsigned char> > &mapAcc) { return false; }
 
@@ -457,7 +457,7 @@ bool CScriptDBViewBacked::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) { re
 bool CScriptDBViewBacked::WriteTxIndex(const vector<pair<uint256, CDiskTxPos> > &list, vector<CScriptDBOperLog> &vTxIndexOperDB) { return pBase->WriteTxIndex(list, vTxIndexOperDB); }
 bool CScriptDBViewBacked::WriteTxOutPut(const uint256 &txid, const vector<CVmOperate> &vOutput, CScriptDBOperLog &operLog) { return pBase->WriteTxOutPut(txid, vOutput, operLog); }
 bool CScriptDBViewBacked::ReadTxOutPut(const uint256 &txid, vector<CVmOperate> &vOutput) { return pBase->ReadTxOutPut(txid, vOutput); }
-bool CScriptDBViewBacked::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &vTxHash) { return pBase->GetTxHashByAddress(keyId, nHeight, vTxHash); }
+bool CScriptDBViewBacked::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &mapTxHash) { return pBase->GetTxHashByAddress(keyId, nHeight, mapTxHash); }
 bool CScriptDBViewBacked::SetTxHashByAddress(const CKeyID &keyId, int nHeight, int nIndex, const string &strTxHash, CScriptDBOperLog &operLog) { return pBase->SetTxHashByAddress(keyId, nHeight, nIndex, strTxHash, operLog); }
 bool CScriptDBViewBacked::GetAllScriptAcc(const CRegID &scriptId, map<vector<unsigned char>, vector<unsigned char> > &mapAcc) { return pBase->GetAllScriptAcc(scriptId, mapAcc); }
 
@@ -729,8 +729,8 @@ bool CScriptDBViewCache::SetTxHashByAddress(const CKeyID &keyId, int nHeight, in
 }
 
 bool CScriptDBViewCache::GetTxHashByAddress(
-    const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &vTxHash) {
-    pBase->GetTxHashByAddress(keyId, nHeight, vTxHash);
+    const CKeyID &keyId, int nHeight, map<vector<unsigned char>, vector<unsigned char> > &mapTxHash) {
+    pBase->GetTxHashByAddress(keyId, nHeight, mapTxHash);
 
     vector<unsigned char> vPreKey = {'A', 'D', 'D', 'R'};
     CDataStream ds1(SER_DISK, CLIENT_VERSION);
@@ -743,9 +743,9 @@ bool CScriptDBViewCache::GetTxHashByAddress(
     while (iterFindKey != mapContractDb.end()) {
         if (0 == memcmp((char *)&iterFindKey->first[0], (char *)&vPreKey[0], 28)) {
             if (iterFindKey->second.empty())
-                vTxHash.erase(iterFindKey->first);
+                mapTxHash.erase(iterFindKey->first);
             else {
-                vTxHash.insert(make_pair(iterFindKey->first, iterFindKey->second));
+                mapTxHash.insert(make_pair(iterFindKey->first, iterFindKey->second));
             }
         } else {
             break;

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -3124,32 +3124,37 @@ Value gettotalassets(const Array& params, bool fHelp) {
 }
 
 Value listtxbyaddr(const Array& params, bool fHelp) {
-    if(fHelp || params.size() != 2) {
-        throw runtime_error("listtxbyaddr \n"
+    if (fHelp || params.size() != 2) {
+        throw runtime_error(
+            "listtxbyaddr \n"
             "\nlist all transactions by their sender/receiver addresss\n"
             "\nArguments:\n"
-            "1.\"address\": (string, required) \n"
-            "2.\"height\": (numeric, required) \n"
-                "\nResult: address related tx hash as array\n"
-            "\nExamples:\n"
-            + HelpExampleCli("listtxbyaddr", "\"5zQPcC1YpFMtwxiH787pSXanUECoGsxUq3KZieJxVG\" \"10023\"")
-            + "\nAs json rpc call\n"
-            + HelpExampleRpc("listtxbyaddr", "\"5zQPcC1YpFMtwxiH787pSXanUECoGsxUq3KZieJxVG\" \"10023\""));
+            "1.\"address\": (string, required)\n"
+            "2.\"height\": (numeric, required)\n"
+            "\nResult: address related tx hash as array\n"
+            "\nExamples:\n" +
+            HelpExampleCli("listtxbyaddr",
+                           "\"wcoA7yUW4fc4m6a2HSk36t4VVxzKUnvq4S\" \"10000\"") +
+            "\nAs json rpc call\n" +
+            HelpExampleRpc("listtxbyaddr",
+                           "\"wcoA7yUW4fc4m6a2HSk36t4VVxzKUnvq4S\", \"10000\""));
     }
+
     string address = params[0].get_str();
-    int height = params[1].get_int();
+    int height     = params[1].get_int();
 
     Object obj;
     {
         CScriptDBViewCache scriptDbView(*pScriptDBTip, true);
-        map<vector<unsigned char>, vector<unsigned char> > mapTxHash;
+        map<vector<unsigned char>, vector<unsigned char>> mapTxHash;
         vector<string> vTxArray;
         CKeyID keyId;
-        if(!GetKeyId(address, keyId)) {
-             throw runtime_error("listtxbyaddr : input address invalid!\n");
+        if (!GetKeyId(address, keyId)) {
+            throw runtime_error("listtxbyaddr : input address invalid!\n");
         }
-        if(!scriptDbView.GetTxHashByAddress(keyId, height, mapTxHash)) {
-             throw runtime_error("call GetTxHashByAddress failed!\n");;
+        if (!scriptDbView.GetTxHashByAddress(keyId, height, mapTxHash)) {
+            throw runtime_error("call GetTxHashByAddress failed!\n");
+            ;
         }
         obj.push_back(Pair("address", address));
         obj.push_back(Pair("height", height));
@@ -3157,7 +3162,7 @@ Value listtxbyaddr(const Array& params, bool fHelp) {
         for (auto item : mapTxHash) {
             arrayObj.push_back(string(item.second.begin(), item.second.end()));
         }
-        obj.push_back(Pair("txarray",arrayObj));
+        obj.push_back(Pair("txarray", arrayObj));
     }
     return obj;
 }

--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -560,12 +560,11 @@ bool CCommonTx::ExecuteTx(int nIndex, CAccountViewCache &view, CValidationState 
         if (!scriptDB.SetTxHashByAddress(sendKeyId, nHeight, nIndex + 1, txundo.txHash.GetHex(),
                                          operAddressToTxLog))
             return false;
-
         txundo.vScriptOperLog.push_back(operAddressToTxLog);
+
         if (!scriptDB.SetTxHashByAddress(revKeyId, nHeight, nIndex + 1, txundo.txHash.GetHex(),
                                          operAddressToTxLog))
             return false;
-
         txundo.vScriptOperLog.push_back(operAddressToTxLog);
     }
 
@@ -775,12 +774,11 @@ bool CContractTx::ExecuteTx(int nIndex, CAccountViewCache &view, CValidationStat
         if (!scriptDB.SetTxHashByAddress(sendKeyId, nHeight, nIndex + 1, txundo.txHash.GetHex(),
                                          operAddressToTxLog))
             return false;
-
         txundo.vScriptOperLog.push_back(operAddressToTxLog);
+
         if (!scriptDB.SetTxHashByAddress(revKeyId, nHeight, nIndex + 1, txundo.txHash.GetHex(),
                                          operAddressToTxLog))
             return false;
-
         txundo.vScriptOperLog.push_back(operAddressToTxLog);
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -474,7 +474,7 @@ bool CScriptDB::GetTxHashByAddress(const CKeyID &keyId, int nHeight, map<vector<
             leveldb::Slice slKey   = pcursor->key();
             leveldb::Slice slValue = pcursor->value();
             CDataStream ssKey(slKey.data(), slKey.data() + slKey.size(), SER_DISK, CLIENT_VERSION);
-            if (0 == memcmp((char *)&ssKey[0], (char *)&ssKeySet[0], 24)) {
+            if (0 == memcmp((char *)&ssKey[0], (char *)&ssKeySet[0], 28)) {
                 vector<unsigned char> vValue;
                 vector<unsigned char> vKey;
                 CDataStream ssValue(slValue.data(), slValue.data() + slValue.size(), SER_DISK, CLIENT_VERSION);


### PR DESCRIPTION
**call rpc with the wrong parameters**

```code
root@ubuntu:~/regtest/node1# ./node1 -datadir=. listtxbyaddr 0-1 -1
error: {"code":-1,"message":"Height out of range."}
```

```code
root@ubuntu:~/regtest/node1# ./node1 -datadir=. listtxbyaddr 0-1 1000000
error: {"code":-1,"message":"Height out of range."}
```

**call rpc with the right parameters**

```code
root@ubuntu:~/regtest/node1# ./node1 -datadir=. listtxbyaddr 0-1 4
{
    "address" : "0-1",
    "height" : 4,
    "txarray" : [
        "f2592386399fe3efbc32330b7407c6e92a08c3b49f01d1cf505e2d62e7ba69cf"
    ]
}
```