### PR TITLE
feature: add startgeneration rpc for performance testing

### DIFF
--- a/src/coind.cpp
+++ b/src/coind.cpp
@@ -137,7 +137,7 @@ std::tuple<bool, boost::thread*> RunCoin(int argc, char* argv[])
 	// Connect coind signal handlers
 	noui_connect();
 
-	fRet = AppInit(argc, argv,threadGroup);
+	fRet = AppInit(argc, argv, threadGroup);
 
 	detectShutdownThread = new boost::thread(boost::bind(&DetectShutdownThread, &threadGroup));
 

--- a/src/main.h
+++ b/src/main.h
@@ -37,9 +37,9 @@ class CContractScript;
 /** the total blocks of burn fee need */
 static const unsigned int DEFAULT_BURN_BLOCK_SIZE = 50;
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 1000000;
+static const unsigned int MAX_BLOCK_SIZE = 10000000;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 7500000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 1024 * 10;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;

--- a/src/main.h
+++ b/src/main.h
@@ -37,9 +37,9 @@ class CContractScript;
 /** the total blocks of burn fee need */
 static const unsigned int DEFAULT_BURN_BLOCK_SIZE = 50;
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 1000000;
+static const unsigned int MAX_BLOCK_SIZE = 2000000;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 1024 * 10;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;

--- a/src/main.h
+++ b/src/main.h
@@ -37,9 +37,9 @@ class CContractScript;
 /** the total blocks of burn fee need */
 static const unsigned int DEFAULT_BURN_BLOCK_SIZE = 50;
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 10000000;
+static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 7500000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 1024 * 10;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;

--- a/src/rpc/rpcblockchain.cpp
+++ b/src/rpc/rpcblockchain.cpp
@@ -630,6 +630,8 @@ Value startgeneration(const Array& params, bool fHelp) {
     }
 
     // TODO: control range of period/batchsize.
+    // TODO: drop the sender/receiver's privkey from wallet.
+
     int64_t period    = params[0].get_uint64();
     int64_t batchSize = params[1].get_uint64();
 

--- a/src/rpc/rpcclient.cpp
+++ b/src/rpc/rpcclient.cpp
@@ -263,6 +263,9 @@ Array RPCConvertValues(const string &strMethod, const vector<string> &strParams)
     /** for mining */
     if (strMethod == "getminedblocks"         && n > 0) ConvertTo<int64_t>(params[0]);
 
+    if (strMethod == "startgeneration"        && n > 0) ConvertTo<uint64_t>(params[0]);
+    if (strMethod == "startgeneration"        && n > 1) ConvertTo<uint64_t>(params[1]);
+
     return params;
 }
 

--- a/src/rpc/rpcdump.cpp
+++ b/src/rpc/rpcdump.cpp
@@ -56,13 +56,13 @@ string static EncodeDumpTime(int64_t nTime) {
 //    return ret.str();
 //}
 
-string DecodeDumpString(const string &str) 
+string DecodeDumpString(const string &str)
 {
     stringstream ret;
     for (unsigned int pos = 0; pos < str.length(); pos++) {
         unsigned char c = str[pos];
         if (c == '%' && pos+2 < str.length()) {
-            c = (((str[pos+1]>>6)*9+((str[pos+1]-'0')&15)) << 4) | 
+            c = (((str[pos+1]>>6)*9+((str[pos+1]-'0')&15)) << 4) |
                 ((str[pos+2]>>6)*9+((str[pos+2]-'0')&15));
             pos += 2;
         }
@@ -130,23 +130,22 @@ Value importprivkey(const Array& params, bool fHelp)
     CCoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) 
+    if (!fGood)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
 
     CKey key = vchSecret.GetKey();
-    if (!key.IsValid()) 
+    if (!key.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
 
     CPubKey pubkey = key.GetPubKey();
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
-       if (!pwalletMain->AddKey(key))
-           throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
-
+        if (!pwalletMain->AddKey(key))
+            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
     }
     Object reply2;
-    reply2.push_back(Pair("imported_key_address",pubkey.GetKeyID().ToAddress()));
+    reply2.push_back(Pair("imported_key_address", pubkey.GetKeyID().ToAddress()));
     return reply2;
 }
 
@@ -192,7 +191,7 @@ Value importwallet(const Array& params, bool fHelp)
     		const Value &obj = find_value(keyItem.get_obj(), "keyid");
     		if(obj.type() == null_type)
     			continue;
-                
+
     		string strKeyId = find_value(keyItem.get_obj(), "keyid").get_str();
     		CKeyID keyId(uint160(ParseHex(strKeyId)));
     		keyCombi.UnSerializeFromJson(keyItem.get_obj());
@@ -268,7 +267,7 @@ Value dumpwallet(const Array& params, bool fHelp) {
 
     string dumpFilePath = params[0].get_str().c_str();
     if (dumpFilePath.find(GetDataDir().string()) != std::string::npos)
-        throw JSONRPCError(RPC_WALLET_FILEPATH_INVALID, 
+        throw JSONRPCError(RPC_WALLET_FILEPATH_INVALID,
             "Wallet file shall not be saved into the Data dir to avoid likely file overwrite.");
 
     ofstream file;

--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -251,7 +251,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getmininginfo",          &getmininginfo,          true,      false,      false },
     { "getnetworkhashps",       &getnetworkhashps,       true,      false,      false },
     { "submitblock",            &submitblock,            true,      false,      false },
-    { "getminedblocks",         &getminedblocks,         true,      true,      false },
+    { "getminedblocks",         &getminedblocks,         true,      true,       false },
 
     /* Raw transactions */
     { "sendtoaddressraw",       &gensendtoaddressraw,    false,     false,     false },  /* deprecated */
@@ -310,7 +310,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getbalance",             &getbalance,             false,     false,      true },
     // { "dispersebalance",        &dispersebalance,        false,     false,      true },
     { "getassets",              &getassets,              false,     false,      true },
-    { "listcontractassets",     &listcontractassets,      false,     false,      true },
+    { "listcontractassets",     &listcontractassets,     false,     false,      true },
     { "submittx",               &sendrawtx,              true,      false,      false}, //deprecated
     { "sendrawtx",              &sendrawtx,              true,      false,      false},
 
@@ -333,6 +333,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getalltxinfo",           &getalltxinfo,           true,      false,      true },
     { "saveblocktofile",        &saveblocktofile,        true,      false,      true },
     { "gethash",                &gethash,                true,      false,      true },
+    { "startgeneration",        &startgeneration,        true,      true,       false},
 };
 
 CRPCTable::CRPCTable() {

--- a/src/rpc/rpcserver.h
+++ b/src/rpc/rpcserver.h
@@ -183,5 +183,6 @@ extern json_spirit::Value getcontractregid(const json_spirit::Array& params, boo
 extern json_spirit::Value listcheckpoint(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value invalidateblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value reconsiderblock(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value startgeneration(const json_spirit::Array& params, bool fHelp);
 
 #endif

--- a/src/rpc/rpctx.cpp
+++ b/src/rpc/rpctx.cpp
@@ -1438,7 +1438,7 @@ if (fHelp || params.size() > 2) {
             //Inblockobj.push_back(Pair("tx", item.first.GetHex()));
             ConfirmTxArry.push_back(item.first.GetHex());
         }
-        if(bUpLimited) {
+        if (bUpLimited) {
             break;
         }
     }

--- a/src/tx.h
+++ b/src/tx.h
@@ -812,7 +812,7 @@ public:
     CRegID regID;
     CKeyID keyID;                  //!< keyID of the account
     CPubKey pubKey;                //!< public key of the account
-    CPubKey minerPubKey;             //!< public key of the account for miner
+    CPubKey minerPubKey;           //!< public key of the account for miner
     uint64_t llValues;             //!< total money
     uint64_t nVoteHeight;          //!< account vote block height
     vector<CVoteFund> vVoteFunds;  //!< account delegate votes order by vote value

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -418,7 +418,7 @@ std::tuple<bool, string> CWallet::CommitTransaction(CBaseTx *pTx) {
 
     uint256 txhash = pTx->GetHash();
     UnConfirmTx[txhash] = pTx->GetNewInstance();
-    bool flag =  CWalletDB(strWalletFile).WriteUnComFirmedTx(txhash,UnConfirmTx[txhash]);
+    bool flag =  CWalletDB(strWalletFile).WriteUnComFirmedTx(txhash, UnConfirmTx[txhash]);
     ::RelayTransaction(pTx, txhash);
 
     return std::make_tuple (flag, txhash.ToString());


### PR DESCRIPTION
**Usage**

```code
startgeneration "period" "batch_size"

Start generation blocks with batch_size transactions in period ms.

Arguments:
1."period" (numeric, required)
2."batch_size" (numeric, required)

Result:

Examples:
> ./coind startgeneration 20 20

As json rpc call
> curl --user myusername -d '{"jsonrpc": "1.0", "id":"curltest", "method": "startgeneration", "params": [20, 20] }' -H 'Content-Type: application/json;' http://127.0.0.1:8332/
```