### PR TITLE
Fix the compile warning "dynamic exception"

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -14,7 +14,7 @@
 #include <memenv.h>
 #include "json/json_spirit_value.h"
 
-void HandleError(const leveldb::Status &status) throw(leveldb_error) {
+void HandleError(const leveldb::Status &status) {
     if (status.ok())
         return;
     LogPrint("INFO","%s\n", status.ToString());
@@ -72,7 +72,7 @@ CLevelDBWrapper::~CLevelDBWrapper() {
     options.env = NULL;
 }
 
-bool CLevelDBWrapper::WriteBatch(CLevelDBBatch &batch, bool fSync) throw(leveldb_error) {
+bool CLevelDBWrapper::WriteBatch(CLevelDBBatch &batch, bool fSync) {
     leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
     HandleError(status);
     return true;

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -21,7 +21,7 @@ public:
     leveldb_error(const string &msg) : runtime_error(msg) {}
 };
 
-void HandleError(const leveldb::Status &status) throw(leveldb_error);
+void HandleError(const leveldb::Status &status);
 
 // Batch of changes queued to be written to a CLevelDBWrapper
 class CLevelDBBatch
@@ -104,7 +104,7 @@ public:
     CLevelDBWrapper(const boost::filesystem::path &path, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
     ~CLevelDBWrapper();
 
-    template<typename K, typename V> bool Read(const K& key, V& value) throw(leveldb_error) {
+    template<typename K, typename V> bool Read(const K& key, V& value) {
     	leveldb::Slice slKey;
     	CDataStream ssKey(SER_DISK, CLIENT_VERSION);
 
@@ -138,13 +138,13 @@ public:
         return true;
     }
 
-    template<typename K, typename V> bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error) {
+    template<typename K, typename V> bool Write(const K& key, const V& value, bool fSync = false) {
         CLevelDBBatch batch;
         batch.Write(key, value);
         return WriteBatch(batch, fSync);
     }
 
-    template<typename K> bool Exists(const K& key) throw(leveldb_error) {
+    template<typename K> bool Exists(const K& key) {
     	leveldb::Slice slKey;
     	CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -172,20 +172,20 @@ public:
         return true;
     }
 
-    template<typename K> bool Erase(const K& key, bool fSync = false) throw(leveldb_error) {
+    template<typename K> bool Erase(const K& key, bool fSync = false) {
         CLevelDBBatch batch;
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
 
-    bool WriteBatch(CLevelDBBatch &batch, bool fSync = false) throw(leveldb_error);
+    bool WriteBatch(CLevelDBBatch &batch, bool fSync = false);
 
     // not available for LevelDB; provide for compatibility with BDB
     bool Flush() {
         return true;
     }
 
-    bool Sync() throw(leveldb_error) {
+    bool Sync() {
         CLevelDBBatch batch;
         return WriteBatch(batch, true);
     }


### PR DESCRIPTION

We remove the "Explicit dynamic exception specification" because it is deprecated in C++11 and is removed in C++17

See the [Dynamic exception specification](https://en.cppreference.com/w/cpp/language/except_spec)
and [noexcept specifier (since C++11)](https://en.cppreference.com/w/cpp/language/noexcept_spec)

### Syntax

|                              |      |                                         |
| ---------------------------- | ---- | --------------------------------------- |
| `throw()`                    | (1)  | (deprecated in C++11)(removed in C++20) |
|                              |      |                                         |
| `throw(typeid, typeid, ...)` | (2)  | (deprecated in C++11)(removed in C++17) |
|                              |      |                                         |

| 1) Non-throwing dynamic exception specification              | (until C++17) |
| ------------------------------------------------------------ | ------------- |
| 1) Same as [`noexcept(true)`](https://en.cppreference.com/w/cpp/language/noexcept_spec) | (since C++17) |

2) Explicit dynamic exception specification

