### PR TITLE
Fixed the issue that RPC server could not bind address "::" and "0.00.0" at the same time

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -235,6 +235,7 @@ libcoin_common_a_SOURCES = \
   random.cpp  \
   rpc/rpcprotocol.cpp \
   support/cleanse.cpp \
+  support/events.cpp \
   sync.cpp \
   syncdata.cpp \
   syncdatadb.cpp \

--- a/src/rpc/httpserver.cpp
+++ b/src/rpc/httpserver.cpp
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Copyright (c) 2017-2019 The WaykiChain Core Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php
 
 #include <rpc/httpserver.h>
 
@@ -316,7 +316,7 @@ static bool HTTPBindAddresses(struct evhttp* http) {
     std::vector<std::pair<std::string, uint16_t>> endpoints;
 
     // Determine what addresses to bind to
-    if (SysCfg().IsArgCount("-rpcbind")) {  
+    if (SysCfg().IsArgCount("-rpcbind")) {
         // bind to specific address
         for (const std::string& strRPCBind : SysCfg().GetMultiArgs("-rpcbind")) {
             int port = http_port;
@@ -324,7 +324,7 @@ static bool HTTPBindAddresses(struct evhttp* http) {
             SplitHostPort(strRPCBind, port, host);
             endpoints.push_back(std::make_pair(host, port));
         }
-    } else { // no set -rpcbind
+    } else {  // no set -rpcbind
         if (SysCfg().IsArgCount("-rpcallowip")) {
             // bind to all ip
             endpoints.push_back(std::make_pair("::", http_port));
@@ -334,22 +334,16 @@ static bool HTTPBindAddresses(struct evhttp* http) {
             endpoints.push_back(std::make_pair("::1", http_port));
             endpoints.push_back(std::make_pair("127.0.0.1", http_port));
         }
-    } 
+    }
 
     // Bind addresses
     for (std::vector<std::pair<std::string, uint16_t>>::iterator i = endpoints.begin();
          i != endpoints.end(); ++i) {
         LogPrint("RPC", "Binding RPC on address %s port %i\n", i->first, i->second);
-        evhttp_bound_socket* bind_handle = evhttp_bind_socket_with_handle(
+        evhttp_bound_socket* bind_handle = evhttp_bind_accept_socket(
             http, i->first.empty() ? nullptr : i->first.c_str(), i->second);
         if (bind_handle) {
             CNetAddr addr;
-            /*
-            if (i->first.empty() || (LookupHost(i->first.c_str(), addr, false) && addr.IsBindAny()))
-            { LogPrintf("WARNING: the RPC server is not safe to expose to untrusted networks such as
-            the public internet\n");
-            }
-            */
             boundSockets.push_back(bind_handle);
         } else {
             LogPrint("ERROR", "Binding RPC on address %s port %i failed.\n", i->first, i->second);

--- a/src/rpc/httpserver.h
+++ b/src/rpc/httpserver.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Copyright (c) 2017-2019 The WaykiChain Core Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php
 
-#ifndef BITCOIN_HTTPSERVER_H
-#define BITCOIN_HTTPSERVER_H
+#ifndef COIN_HTTPSERVER_H
+#define COIN_HTTPSERVER_H
 
 #include <string>
 #include <stdint.h>
@@ -150,4 +150,4 @@ private:
 
 std::string urlDecode(const std::string &urlEncoded);
 
-#endif // BITCOIN_HTTPSERVER_H
+#endif // COIN_HTTPSERVER_H

--- a/src/support/events.cpp
+++ b/src/support/events.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2017-2019 The WaykiChain Core Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php
+
+#include "events.h"
+#include <util.h>
+#include <event2/event.h>
+#include <event2/thread.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/http.h>
+#include <event2/keyvalq_struct.h>
+#include <event2/util.h>
+#include <event2/listener.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// functions copy from libevent/http.c, and support to bind with IPV6_V6ONLY
+
+#ifdef SOCK_NONBLOCK
+#define EVUTIL_SOCK_NONBLOCK SOCK_NONBLOCK
+#else
+#define EVUTIL_SOCK_NONBLOCK 0x4000000
+#endif
+#ifdef SOCK_CLOEXEC
+#define EVUTIL_SOCK_CLOEXEC SOCK_CLOEXEC
+#else
+#define EVUTIL_SOCK_CLOEXEC 0x80000000
+#endif
+
+/** copy from the implements of ev_http */
+static struct evutil_addrinfo* make_addrinfo(const char* address, ev_uint16_t port) {
+    struct evutil_addrinfo* ai = NULL;
+
+    struct evutil_addrinfo hints;
+    char strport[NI_MAXSERV];
+    int ai_result;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    /* turn NULL hostname into INADDR_ANY, and skip looking up any address
+     * types we don't have an interface to connect to. */
+    hints.ai_flags = EVUTIL_AI_PASSIVE | EVUTIL_AI_ADDRCONFIG;
+    evutil_snprintf(strport, sizeof(strport), "%d", port);
+    if ((ai_result = evutil_getaddrinfo(address, strport, &hints, &ai)) != 0) {
+        if (ai_result == EVUTIL_EAI_SYSTEM) {
+            LogPrint("ERROR", "httpserver getaddrinfo error, address=%s", address);
+        } else {
+            LogPrint("ERROR", "httpserver getaddrinfo error: %s, address=%s",
+                     evutil_gai_strerror(ai_result), address);
+        }
+        return (NULL);
+    }
+
+    return (ai);
+}
+
+/* Faster version of evutil_make_socket_closeonexec for internal use.
+ *
+ * Requires that no F_SETFD flags were previously set on the fd.
+ */
+static int evutil_fast_socket_closeonexec(evutil_socket_t fd) {
+#if !defined(_WIN32) && defined(EVENT__HAVE_SETFD)
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+        LogPrint("ERROR", "evutil_fast_socket_closeonexec fcntl(%d, F_SETFD)", fd);
+        return -1;
+    }
+#endif
+    return 0;
+}
+
+/* Faster version of evutil_make_socket_nonblocking for internal use.
+ *
+ * Requires that no F_SETFL flags were previously set on the fd.
+ */
+static int evutil_fast_socket_nonblocking(evutil_socket_t fd) {
+#ifdef _WIN32
+    return evutil_make_socket_nonblocking(fd);
+#else
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1) {
+        LogPrint("ERROR", "evutil_fast_socket_nonblocking fcntl(%d, F_SETFL)", fd);
+        return -1;
+    }
+    return 0;
+#endif
+}
+
+/* Internal wrapper around 'socket' to provide Linux-style support for
+ * syscall-saving methods where available.
+ *
+ * In addition to regular socket behavior, you can use a bitwise or to set the
+ * flags EVUTIL_SOCK_NONBLOCK and EVUTIL_SOCK_CLOEXEC in the 'type' argument,
+ * to make the socket nonblocking or close-on-exec with as few syscalls as
+ * possible.
+ */
+evutil_socket_t evutil_socket_(int domain, int type, int protocol) {
+    evutil_socket_t r;
+#if defined(SOCK_NONBLOCK) && defined(SOCK_CLOEXEC)
+    r = socket(domain, type, protocol);
+    if (r >= 0)
+        return r;
+    else if ((type & (SOCK_NONBLOCK | SOCK_CLOEXEC)) == 0)
+        return -1;
+#endif
+#define SOCKET_TYPE_MASK (~(EVUTIL_SOCK_NONBLOCK | EVUTIL_SOCK_CLOEXEC))
+    r = socket(domain, type & SOCKET_TYPE_MASK, protocol);
+    if (r < 0) return -1;
+    if (type & EVUTIL_SOCK_NONBLOCK) {
+        if (evutil_fast_socket_nonblocking(r) < 0) {
+            evutil_closesocket(r);
+            return -1;
+        }
+    }
+    if (type & EVUTIL_SOCK_CLOEXEC) {
+        if (evutil_fast_socket_closeonexec(r) < 0) {
+            evutil_closesocket(r);
+            return -1;
+        }
+    }
+    return r;
+}
+
+/* Create a non-blocking socket and bind it */
+/* todo: rename this function */
+static evutil_socket_t bind_socket_ai(struct evutil_addrinfo* ai, int reuse) {
+    evutil_socket_t fd;
+
+    int on = 1, r;
+
+    /* Create listen socket */
+    fd = evutil_socket_(ai ? ai->ai_family : AF_INET,
+                        SOCK_STREAM | EVUTIL_SOCK_NONBLOCK | EVUTIL_SOCK_CLOEXEC, 0);
+    if (fd == -1) {
+        // event_sock_warn(-1, "socket");
+        return (-1);
+    }
+
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (void*)&on, sizeof(on)) < 0) {
+        LogPrint("ERROR", "bind_socket_ai setsockopt(%d, SOL_SOCKET, SO_KEEPALIVE) failed", fd);
+        evutil_closesocket(fd);
+        return (-1);
+    }
+
+    if (evutil_make_listen_socket_reuseable(fd) < 0) {
+        LogPrint("ERROR", "bind_socket_ai evutil_make_listen_socket_reuseable failed");
+        evutil_closesocket(fd);
+        return (-1);
+    }
+
+#if defined(IPV6_V6ONLY)
+    int ai_family = ai ? ai->ai_family : AF_INET;
+    // AF_INET6
+    if (ai_family == PF_INET6) {
+        on = 1;
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&on, (ev_socklen_t)sizeof(on)) < 0) {
+            LogPrint("ERROR", "bind_socket_ai evutil_make_listen_socket_ipv6only failed");
+            return (-1);
+        }
+    }
+#endif
+
+    if (ai != NULL) {
+        r = bind(fd, ai->ai_addr, (ev_socklen_t)ai->ai_addrlen);
+        if (r == -1) {
+            int serrno = EVUTIL_SOCKET_ERROR();
+            LogPrint("ERROR", "bind_socket_ai bind failed, err: %s",
+                     evutil_socket_error_to_string(serrno));
+            evutil_closesocket(fd);
+            return (-1);
+        }
+    }
+
+    return (fd);
+}
+
+static evutil_socket_t bind_socket(const char* address, ev_uint16_t port, int reuse) {
+    evutil_socket_t fd;
+    struct evutil_addrinfo* aitop = NULL;
+
+    /* just create an unbound socket */
+    if (address == NULL && port == 0) return bind_socket_ai(NULL, 0);
+
+    aitop = make_addrinfo(address, port);
+
+    if (aitop == NULL) return (-1);
+
+    fd = bind_socket_ai(aitop, reuse);
+
+    evutil_freeaddrinfo(aitop);
+
+    return (fd);
+}
+
+struct evhttp_bound_socket* evhttp_bind_accept_socket(struct evhttp* http, const char* address,
+                                                      ev_uint16_t port) {
+    evutil_socket_t fd;
+    struct evhttp_bound_socket* bound;
+    int serrno;
+
+    if ((fd = bind_socket(address, port, 1 /*reuse*/)) == -1) return (NULL);
+
+    if (listen(fd, 128) == -1) {
+        serrno = EVUTIL_SOCKET_ERROR();
+        LogPrint("ERROR", "evhttp_bind_accept_socket listen failed! err: ",
+                 evutil_socket_error_to_string(serrno));
+        evutil_closesocket(fd);
+        EVUTIL_SET_SOCKET_ERROR(serrno);
+        return (NULL);
+    }
+
+    bound = evhttp_accept_socket_with_handle(http, fd);
+
+    if (bound != NULL) {
+        LogPrint("LIBEVENT",
+                 "evhttp_bind_accept_socket Bound to port %d - Awaiting connections ... ", port);
+        return (bound);
+    }
+
+    return (NULL);
+}

--- a/src/support/events.h
+++ b/src/support/events.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Copyright (c) 2017-2019 The WaykiChain Core Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php
 
-#ifndef BITCOIN_SUPPORT_EVENTS_H
-#define BITCOIN_SUPPORT_EVENTS_H
+#ifndef COIN_SUPPORT_EVENTS_H
+#define COIN_SUPPORT_EVENTS_H
 
 #include <ios>
 #include <memory>
@@ -53,4 +53,17 @@ inline raii_evhttp_connection obtain_evhttp_connection_base(struct event_base* b
     return result;
 }
 
-#endif // BITCOIN_SUPPORT_EVENTS_H
+/**
+ * Like evhttp_accept_socket_with_handle(), but support to bind ipv6 with IPV6_V6ONLY.
+ *
+ * The returned pointer is not valid after http is freed.
+ *
+ * @param http a pointer to an evhttp object
+ * @param fd a socket fd that is ready for accepting connections
+ * @return Handle for the socket on success, NULL on failure.
+ * @see evhttp_accept_socket(), evhttp_del_accept_socket()
+ */
+struct evhttp_bound_socket* evhttp_bind_accept_socket(struct evhttp* http,
+                                                             const char* address, ev_uint16_t port);
+
+#endif // COIN_SUPPORT_EVENTS_H


### PR DESCRIPTION
See the issue of libevent: [Consider setting IPV6_V6ONLY on IPv6 sockets to prevent automatic dual-stack binding #394](https://github.com/libevent/libevent/issues/394#).
>Using the HTTP server under Linux, the evhttp_bind_socket_handle() function with a host parameter of :: will by default on many distributions make the socket dual-stack, meaning that a subsequent attempt to bind() to 0.0.0.0 will fail.

So we implement evhttp_bind_accept_socket() function similar to evhttp_bind_socket_handle(), but  supports to bind ipv6 address with IPV6_V6ONLY.
