### PR TITLE
 fix: fail to check 0-1 ~ 0-12 accounts' regid

### DIFF
--- a/src/accounts/accounts.cpp
+++ b/src/accounts/accounts.cpp
@@ -317,18 +317,20 @@ Object CAccount::ToJsonObj(bool isAddress) const {
     }
 
     Object obj;
-    bool isMature =
-        chainActive.Height() - (int)regID.GetHeight() > kRegIdMaturePeriodByBlock ? true : false;
-    obj.push_back(Pair("address",       keyID.ToAddress()));
-    obj.push_back(Pair("keyID",         keyID.ToString()));
-    obj.push_back(Pair("publicKey",     pubKey.ToString()));
-    obj.push_back(Pair("minerPubKey",   minerPubKey.ToString()));
-    obj.push_back(Pair("regID",         regID.ToString()));
-    obj.push_back(Pair("regIDMature",   isMature));
-    obj.push_back(Pair("balance",       bcoinBalance));
-    obj.push_back(Pair("updateHeight",  nVoteHeight));
-    obj.push_back(Pair("votes",         receivedVotes));
-    obj.push_back(Pair("voteFundList",  voteFundArray));
+    bool isMature = (regID.GetHeight() == 0 ||
+                     chainActive.Height() - (int)regID.GetHeight() > kRegIdMaturePeriodByBlock)
+                        ? true
+                        : false;
+    obj.push_back(Pair("address", keyID.ToAddress()));
+    obj.push_back(Pair("key_id", keyID.ToString()));
+    obj.push_back(Pair("public_key", pubKey.ToString()));
+    obj.push_back(Pair("miner_public_key", minerPubKey.ToString()));
+    obj.push_back(Pair("reg_id", regID.ToString()));
+    obj.push_back(Pair("reg_id_mature", isMature));
+    obj.push_back(Pair("balance", bcoinBalance));
+    obj.push_back(Pair("update_height", nVoteHeight));
+    obj.push_back(Pair("votes", receivedVotes));
+    obj.push_back(Pair("vote_fund_list", voteFundArray));
     return obj;
 }
 

--- a/src/accounts/accounts.cpp
+++ b/src/accounts/accounts.cpp
@@ -317,10 +317,8 @@ Object CAccount::ToJsonObj(bool isAddress) const {
     }
 
     Object obj;
-    bool isMature = regID.GetHeight() > 0 && chainActive.Height() - (int)regID.GetHeight() >
-                                                 kRegIdMaturePeriodByBlock
-                        ? true
-                        : false;
+    bool isMature =
+        chainActive.Height() - (int)regID.GetHeight() > kRegIdMaturePeriodByBlock ? true : false;
     obj.push_back(Pair("address",       keyID.ToAddress()));
     obj.push_back(Pair("keyID",         keyID.ToString()));
     obj.push_back(Pair("publicKey",     pubKey.ToString()));


### PR DESCRIPTION
**What's the problem**
```code
root@7bfb2b17e40a:/WaykiChain# ./coind -datadir=. getblockcount
21914

root@7bfb2b17e40a:/WaykiChain# ./coind -datadir=. getaccountinfo "0-3"
{
    "address" : "wNuJM44FPC5NxearNLP98pg295VqP7hsqu",
    "keyID" : "23e8b4ac5e3dea621474cad9d9dc4323018856c9",
    "publicKey" : "025a37cb6ec9f63bb17e562865e006f0bafa9afbd8a846bd87fc8ff9e35db1252e",
    "minerPubKey" : "",
    "regID" : "0-3",
    "regIDMature" : false,
    "balance" : 0,
    "updateHeight" : 0,
    "votes" : 210000000000000,
    "voteFundList" : [
    ],
    "position" : "inblock"
}
```

It's wrong to consider `0-3` account's reg_id is immature if the height is up to 21914(bigger than 100).

**what it's should be**
```code
root@7bfb2b17e40a:/WaykiChain# ./coind -datadir=. getaccountinfo 0-3
{
    "address" : "wNuJM44FPC5NxearNLP98pg295VqP7hsqu",
    "key_id" : "23e8b4ac5e3dea621474cad9d9dc4323018856c9",
    "public_key" : "025a37cb6ec9f63bb17e562865e006f0bafa9afbd8a846bd87fc8ff9e35db1252e",
    "miner_public_key" : "",
    "reg_id" : "0-3",
    "reg_id_mature" : true,
    "balance" : 0,
    "update_height" : 0,
    "votes" : 210000000000000,
    "vote_fund_list" : [
    ],
    "position" : "inblock"
}
```